### PR TITLE
Add multiple dependency graph output formats and stdin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build:dev` script (source maps for local debugging).
 - New CLI exports `run(argv)` and `CliError` from `lib/cli` for programmatic use
   and testing.
+- **Multiple output formats** via `-o, --format <mermaid|edges|json|dot>`
+  (default `mermaid`). The new formats are aimed at scripts and AI agents that
+  need cheap, structured access to the workspace topology without re-parsing
+  the much larger raw Nx graph JSON:
+  - `edges` — minimal `source target` lines.
+  - `json` — compact `{ "nodes": [...], "edges": [[src, dst], ...] }`.
+  - `dot` — Graphviz `digraph` declaration, pipe into `dot -Tsvg`.
+- New `--raw` flag to emit Mermaid without the surrounding
+  `` ```mermaid `` markdown fence.
+- Public exports `formatGraph`, `isOutputFormat`, `OUTPUT_FORMATS`, and the
+  `OutputFormat` type from `lib/formatters` for programmatic use.
 - `NXGraphFileLoader.readNXGraph` now validates the parsed JSON and throws a
   descriptive error if the file is not a recognisable Nx graph dump (missing
   `graph`, `graph.nodes`, or `graph.dependencies`).
@@ -26,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `lib/cli.ts` to expose a pure `run(argv): string` entry point and a
   `CliError` class; the script is now executed only when invoked directly
   (`require.main === module`). Test coverage on `cli.ts` went from 0% to 100%.
+- `NxMermaidGrapher.getGraphSnippet` now takes an optional second argument
+  `format: OutputFormat = 'mermaid'`. Existing callers are unaffected.
 - Internal cleanup of `core.ts` and `di-graph.ds.ts`: linear-time
   `getGraphSnippet` (was quadratic in shape due to array spreading), `Set`-based
   exclusion lookup in `filterOutLibs`, and a properly typed `Map<string, string[]>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build:dev` script (source maps for local debugging).
 - New CLI exports `run(argv)` and `CliError` from `lib/cli` for programmatic use
   and testing.
-- **Multiple output formats** via `-o, --format <mermaid|edges|json|dot>`
+- **Multiple output formats** via `-o, --format <mermaid|edges|json|dot|stats>`
   (default `mermaid`). The new formats are aimed at scripts and AI agents that
   need cheap, structured access to the workspace topology without re-parsing
   the much larger raw Nx graph JSON:
   - `edges` — minimal `source target` lines.
   - `json` — compact `{ "nodes": [...], "edges": [[src, dst], ...] }`.
   - `dot` — Graphviz `digraph` declaration, pipe into `dot -Tsvg`.
+  - `stats` — plain-text summary: counts, roots/leaves, cycle detection,
+    max depth + an example longest path, and per-project fan-in/fan-out
+    sorted by most depended-on first.
 - New `--raw` flag to emit Mermaid without the surrounding
   `` ```mermaid `` markdown fence.
 - Public exports `formatGraph`, `isOutputFormat`, `OUTPUT_FORMATS`, and the
   `OutputFormat` type from `lib/formatters` for programmatic use.
+- Public exports `computeStats`, `GraphStats`, and `ProjectStats` from
+  `lib/stats` for callers that want the structured stats data instead of the
+  rendered text summary.
 - `NXGraphFileLoader.readNXGraph` now validates the parsed JSON and throws a
   descriptive error if the file is not a recognisable Nx graph dump (missing
   `graph`, `graph.nodes`, or `graph.dependencies`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public exports `computeStats`, `GraphStats`, and `ProjectStats` from
   `lib/stats` for callers that want the structured stats data instead of the
   rendered text summary.
+- New `excludeLibs(graph, excluded)` export. Lifts the previously-private
+  filtering logic out of `NxMermaidGrapher` so programmatic callers can
+  compose it with `formatGraph` and `computeStats`
+  (e.g. `computeStats(excludeLibs(graph, ['noisy-lib']))`).
 - `NXGraphFileLoader.readNXGraph` now validates the parsed JSON and throws a
   descriptive error if the file is not a recognisable Nx graph dump (missing
   `graph`, `graph.nodes`, or `graph.dependencies`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     sorted by most depended-on first.
 - New `--raw` flag to emit Mermaid without the surrounding
   `` ```mermaid `` markdown fence.
+- **Read from stdin** via `--stdin` (or the idiomatic `-f -`). Lets agents
+  and CI steps pipe `nx graph --file=/dev/stdout` straight into the tool
+  without round-tripping through a temp file. Mutually exclusive with `-f`.
 - Public exports `formatGraph`, `isOutputFormat`, `OUTPUT_FORMATS`, and the
   `OutputFormat` type from `lib/formatters` for programmatic use.
 - Public exports `computeStats`, `GraphStats`, and `ProjectStats` from

--- a/README.md
+++ b/README.md
@@ -4,12 +4,25 @@
 
 A utility to create [`MermaidJS`](https://mermaid.js.org/) graphs for [NX dependency graphs](https://nx.dev/packages/nx/documents/dep-graph).
 
+> [!TIP]
+> **Using this from an AI coding agent?** `nx-mermaid-grapher` is designed to be
+> a token-cheap window into an Nx workspace. Instead of feeding the model the
+> full `nx graph` JSON (often tens to hundreds of kB), have the agent shell out
+> to this CLI with `--format edges` or `--format json` to get a compact view of
+> the dependency topology. The default `mermaid` output is great for **showing
+> the result back to the user** — it renders natively in GitHub/GitLab markdown
+> and in VS Code-based editors (Cursor, Windsurf, VSCodium, ...) with a Mermaid
+> preview extension. See [Output formats](#output-formats) below for the short
+> version, or the [Usage guide](./docs/usage-guide.md) for a full walkthrough
+> of every format with realistic examples.
+
 <!-- omit in toc -->
 ## Table of Contents
 - [nx-mermaid-grapher](#nx-mermaid-grapher)
   - [Example](#example)
   - [Usage](#usage)
     - [CLI](#cli)
+      - [Output formats](#output-formats)
     - [Code](#code)
   - [Recipes](#recipes)
     - [Render only the libs affected by a PR](#render-only-the-libs-affected-by-a-pr)
@@ -93,14 +106,16 @@ npx nx-mermaid-grapher -f file.json
 Then, run it with `-f [PATH]` or `--file [PATH]` parameter providing the path for your NX graph JSON output file.
 
 ```
-Usage: nx-mermaid-grapher -f <path> [-e <lib>]...
+Usage: nx-mermaid-grapher -f <path> [-o <format>] [-e <lib>]... [--raw]
 
 Options:
-  -f, --file <path>     NX graph output file
-                        (see: https://nx.dev/packages/nx/documents/dep-graph#file)
-  -e, --exclude <lib>   Exclude a library (repeatable)
-  -h, --help            Show help
-  -V, --version         Show version
+  -f, --file <path>      NX graph output file
+                         (see: https://nx.dev/packages/nx/documents/dep-graph#file)
+  -o, --format <format>  Output format: mermaid | edges | json | dot (default: mermaid)
+  -e, --exclude <lib>    Exclude a library (repeatable)
+      --raw              Emit raw Mermaid (no ```mermaid markdown fence)
+  -h, --help             Show help
+  -V, --version          Show version
 ```
 
 **Example**:
@@ -114,6 +129,69 @@ Optionally you can exclude one, or multiple libraries. For example:
 ```bash
 npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -e lending-infrastructure -e lending-ui-rest
 ```
+
+#### Output formats
+
+Pass `-o <format>` (or `--format`) to switch the output. The default is
+`mermaid`; the others exist so scripts and AI agents can consume the topology
+cheaply without re-parsing the much larger raw Nx graph JSON. Concretely, on
+the bundled DDD example fixture:
+
+| Output                | Size      |
+| --------------------- | --------- |
+| raw `nx graph` JSON   | ~49,500 B |
+| `-o mermaid` (default)| ~770 B    |
+| `-o json`             | ~935 B    |
+| `-o edges`            | ~640 B    |
+
+The exact ratio depends on the workspace, but the trend is the same: the raw
+graph carries per-project metadata (`files`, `targets`, `tags`, …) that this
+tool strips down to just the topology.
+
+| Format    | Use case                                                                                        |
+| --------- | ----------------------------------------------------------------------------------------------- |
+| `mermaid` | Paste into a Markdown doc, PR description, GitHub/GitLab README, or a chat reply. Renders natively on GitHub/GitLab and in VS Code-based editors (Cursor, Windsurf, VSCodium, …) with a Mermaid preview extension. Wrapped in a `\`\`\`mermaid` fence by default. |
+| `edges`   | One `source target` pair per line. Minimal whitespace, easy to `awk`/`grep`/feed to an LLM.     |
+| `json`    | Compact `{ "nodes": [...], "edges": [[src, dst], ...] }`. Includes isolated nodes.              |
+| `dot`     | Graphviz `digraph` declaration; pipe into `dot -Tsvg` to render an image.                       |
+
+Examples:
+
+```bash
+# Raw Mermaid body (no markdown fence) — handy when piping into a templater.
+npx nx-mermaid-grapher -f graph.json --raw
+
+# Plain edge list — the cheapest format for an AI agent to reason about.
+npx nx-mermaid-grapher -f graph.json -o edges
+
+# Compact JSON.
+npx nx-mermaid-grapher -f graph.json -o json
+
+# Graphviz, rendered to SVG.
+npx nx-mermaid-grapher -f graph.json -o dot | dot -Tsvg > graph.svg
+```
+
+> [!TIP]
+> **For AI agents and tool authors.** Pick the format that matches what the
+> model actually needs:
+>
+> - **Reasoning about structure** ("which libs depend on `auth`?", "is there a
+>   cycle?") → use `--format edges` or `--format json`. Both are much smaller
+>   than the raw Nx graph and have predictable shapes the model can parse
+>   without hallucinating fields.
+> - **Showing the user the topology** in a chat reply, a PR comment, or a
+>   markdown report → use the default `mermaid` output. It renders natively on
+>   GitHub/GitLab and in VS Code-based editors (Cursor, Windsurf, VSCodium, …)
+>   with a Mermaid preview extension.
+> - **Producing an image** for a doc site or a Slack message → use
+>   `--format dot | dot -Tsvg` (or `-Tpng`).
+>
+> Combine with `-e <lib>` to drop noisy projects from the rendered subset
+> before passing it to the model — fewer tokens, less distraction.
+
+For a full walkthrough of every format with realistic outputs, recipes for
+querying the edge list with `awk`, and a programmatic-API example, see the
+[Usage guide](./docs/usage-guide.md).
 
 ### Code
 
@@ -232,6 +310,7 @@ sticky comment in place, swap the last step for an action like
 
 ## Project documents
 
+- [Usage guide](./docs/usage-guide.md) — every output format with realistic examples and recipes.
 - [Changelog](./CHANGELOG.md) — release history and notable changes.
 - [Contributing](./CONTRIBUTING.md) — how to set up the project and propose changes.
 - [Code of Conduct](./CODE_OF_CONDUCT.md) — community expectations.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ the bundled DDD example fixture:
 | `-o mermaid` (default)| ~770 B    |
 | `-o json`             | ~935 B    |
 | `-o edges`            | ~640 B    |
+| `-o stats`            | ~730 B    |
 
 The exact ratio depends on the workspace, but the trend is the same: the raw
 graph carries per-project metadata (`files`, `targets`, `tags`, …) that this
@@ -154,6 +155,7 @@ tool strips down to just the topology.
 | `edges`   | One `source target` pair per line. Minimal whitespace, easy to `awk`/`grep`/feed to an LLM.     |
 | `json`    | Compact `{ "nodes": [...], "edges": [[src, dst], ...] }`. Includes isolated nodes.              |
 | `dot`     | Graphviz `digraph` declaration; pipe into `dot -Tsvg` to render an image.                       |
+| `stats`   | Plain-text summary: counts, roots/leaves, cycle flag, max depth + example longest path, per-project fan-in/fan-out. Single token-cheap snapshot of workspace shape. |
 
 Examples:
 
@@ -169,16 +171,23 @@ npx nx-mermaid-grapher -f graph.json -o json
 
 # Graphviz, rendered to SVG.
 npx nx-mermaid-grapher -f graph.json -o dot | dot -Tsvg > graph.svg
+
+# One-shot summary (counts, roots/leaves, cycle check, hottest projects).
+npx nx-mermaid-grapher -f graph.json -o stats
 ```
 
 > [!TIP]
 > **For AI agents and tool authors.** Pick the format that matches what the
 > model actually needs:
 >
-> - **Reasoning about structure** ("which libs depend on `auth`?", "is there a
->   cycle?") → use `--format edges` or `--format json`. Both are much smaller
->   than the raw Nx graph and have predictable shapes the model can parse
->   without hallucinating fields.
+> - **One-shot orientation** ("how big is this workspace?", "any cycles?",
+>   "what are the load-bearing libs?") → use `--format stats`. A single block
+>   of text covers counts, roots/leaves, cycle detection, max depth, and
+>   per-project fan-in/fan-out.
+> - **Reasoning about structure** ("which libs depend on `auth`?", "show me
+>   the path from `library` to `shared-domain`") → use `--format edges` or
+>   `--format json`. Both are much smaller than the raw Nx graph and have
+>   predictable shapes the model can parse without hallucinating fields.
 > - **Showing the user the topology** in a chat reply, a PR comment, or a
 >   markdown report → use the default `mermaid` output. It renders natively on
 >   GitHub/GitLab and in VS Code-based editors (Cursor, Windsurf, VSCodium, …)

--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ npx nx-mermaid-grapher -f file.json
 Then, run it with `-f [PATH]` or `--file [PATH]` parameter providing the path for your NX graph JSON output file.
 
 ```
-Usage: nx-mermaid-grapher -f <path> [-o <format>] [-e <lib>]... [--raw]
+Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [--raw]
 
 Options:
-  -f, --file <path>      NX graph output file
+  -f, --file <path>      NX graph output file. Pass `-` to read from stdin
                          (see: https://nx.dev/packages/nx/documents/dep-graph#file)
-  -o, --format <format>  Output format: mermaid | edges | json | dot (default: mermaid)
+      --stdin            Read the graph JSON from stdin (alias for `-f -`)
+  -o, --format <format>  Output format (default: mermaid).
+                         One of: mermaid, edges, json, dot, stats
   -e, --exclude <lib>    Exclude a library (repeatable)
       --raw              Emit raw Mermaid (no ```mermaid markdown fence)
   -h, --help             Show help
@@ -128,6 +130,13 @@ Optionally you can exclude one, or multiple libraries. For example:
 
 ```bash
 npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -e lending-infrastructure -e lending-ui-rest
+```
+
+Or skip the temp file entirely and pipe `nx graph`'s output straight in:
+
+```bash
+nx graph --file=/dev/stdout | npx nx-mermaid-grapher --stdin -o stats
+# (or the idiomatic form: `... | npx nx-mermaid-grapher -f -`)
 ```
 
 #### Output formats

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -12,11 +12,12 @@ wiring it into a script, an AI agent prompt, or a CI workflow.
 ## Table of contents
 
 - [Getting an Nx graph dump](#getting-an-nx-graph-dump)
-- [The four output formats](#the-four-output-formats)
+- [The output formats](#the-output-formats)
   - [`mermaid` (default)](#mermaid-default)
   - [`edges`](#edges)
   - [`json`](#json)
   - [`dot`](#dot)
+  - [`stats`](#stats)
 - [Filtering with `--exclude`](#filtering-with---exclude)
 - [Using the library programmatically](#using-the-library-programmatically)
 - [Pointers](#pointers)
@@ -36,7 +37,7 @@ npx nx graph --affected --file=affected.json --base=origin/develop
 `nx-mermaid-grapher` then reads that file and emits whichever format you ask
 for on stdout.
 
-## The four output formats
+## The output formats
 
 Pick one with `-o <format>` (or `--format <format>`). The default is `mermaid`.
 
@@ -269,6 +270,53 @@ npx nx-mermaid-grapher -f graph.json -o dot | dot -Tsvg > graph.svg
 npx nx-mermaid-grapher -f graph.json -o dot | dot -Tpng > graph.png
 ```
 
+### `stats`
+
+**When to use it.** When you want a single token-cheap snapshot of workspace
+shape — for "is this codebase healthy?" reasoning, for an AI agent's first
+look at the repo, or just to spot the load-bearing libraries at a glance.
+
+The summary covers:
+
+- Total node and edge counts.
+- Roots (projects with no incoming edges) and leaves (no outgoing edges).
+- Cycle detection — flagged with `cycles: yes` if any directed cycle exists.
+- Max dependency depth (longest path in edges) plus one example longest path.
+  Reported as `cycles: yes (max depth omitted)` when cycles are present.
+- Per-project fan-in / fan-out, sorted with the most depended-on projects
+  first.
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -o stats
+```
+
+```
+graph stats
+  nodes:     8
+  edges:     18
+  roots:     1
+    library
+  leaves:    1
+    shared-domain
+  cycles:    none
+  max depth: 6
+    library -> lending-ui-rest -> lending-infrastructure -> lending-application -> catalogue -> shared-infrastructure-nestjs-cqrs-events -> shared-domain
+
+per-project (fan-in / fan-out):
+  shared-domain                              5 / 0
+  lending-domain                             4 / 1
+  lending-application                        2 / 3
+  lending-infrastructure                     2 / 4
+  catalogue                                  2 / 2
+  shared-infrastructure-nestjs-cqrs-events   2 / 1
+  lending-ui-rest                            1 / 3
+  library                                    0 / 4
+```
+
+The format is plain text by design (cheap for both humans and LLMs to skim).
+If you need it as structured data, call [`computeStats`](#using-the-library-programmatically)
+from the library API instead — it returns a typed `GraphStats` object.
+
 ## Filtering with `--exclude`
 
 Any output format can be narrowed by excluding noisy projects. `-e` (or
@@ -307,6 +355,12 @@ const compactJson = core.getGraphSnippet(['lending-infrastructure'], 'json');
 // Or call `formatGraph` directly if you already have a graph object:
 import { formatGraph } from 'nx-mermaid-grapher';
 const dot = formatGraph({ a: ['b'], b: [] }, 'dot');
+
+// Want stats as a typed object instead of a printed summary?
+import { computeStats, type GraphStats } from 'nx-mermaid-grapher';
+const stats: GraphStats = computeStats({ a: ['b', 'c'], b: ['c'], c: [] });
+//   { nodes: 3, edges: 3, roots: ['a'], leaves: ['c'], hasCycles: false,
+//     maxDepth: 2, longestPath: ['a', 'b', 'c'], projects: [...] }
 ```
 
 You can also bring your own graph data structure by implementing `IGraph<T>`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -373,6 +373,12 @@ import { computeStats, type GraphStats } from 'nx-mermaid-grapher';
 const stats: GraphStats = computeStats({ a: ['b', 'c'], b: ['c'], c: [] });
 //   { nodes: 3, edges: 3, roots: ['a'], leaves: ['c'], hasCycles: false,
 //     maxDepth: 2, longestPath: ['a', 'b', 'c'], projects: [...] }
+
+// Need stats or a rendered graph with some libs filtered out? Compose
+// `excludeLibs` with either:
+import { excludeLibs } from 'nx-mermaid-grapher';
+const trimmedStats = computeStats(excludeLibs(graph, ['noisy-lib']));
+const trimmedDot = formatGraph(excludeLibs(graph, ['noisy-lib']), 'dot');
 ```
 
 You can also bring your own graph data structure by implementing `IGraph<T>`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -37,6 +37,18 @@ npx nx graph --affected --file=affected.json --base=origin/develop
 `nx-mermaid-grapher` then reads that file and emits whichever format you ask
 for on stdout.
 
+If you would rather not write a temp file at all — for example in an AI agent
+loop or a CI step — pipe the JSON directly into the CLI on stdin:
+
+```bash
+nx graph --file=/dev/stdout | npx nx-mermaid-grapher --stdin -o stats
+# `--stdin` is an alias for the idiomatic `-f -`:
+nx graph --file=/dev/stdout | npx nx-mermaid-grapher -f -
+```
+
+`--stdin` and `-f` are mutually exclusive. The error you get when both are
+passed is intentional — it usually means the upstream pipeline is wrong.
+
 ## The output formats
 
 Pick one with `-o <format>` (or `--format <format>`). The default is `mermaid`.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1,0 +1,322 @@
+# Usage guide
+
+This guide walks through every output format `nx-mermaid-grapher` can produce,
+with real examples generated from the bundled
+[`tests/mocks/ddd-example.graph.json`](../tests/mocks/ddd-example.graph.json)
+fixture (a small DDD-style Nx workspace with 8 projects and 18 dependencies).
+
+For a one-page overview, the [README](../README.md) is the right place. This
+page is for when you want to see exactly what each format looks like before
+wiring it into a script, an AI agent prompt, or a CI workflow.
+
+## Table of contents
+
+- [Getting an Nx graph dump](#getting-an-nx-graph-dump)
+- [The four output formats](#the-four-output-formats)
+  - [`mermaid` (default)](#mermaid-default)
+  - [`edges`](#edges)
+  - [`json`](#json)
+  - [`dot`](#dot)
+- [Filtering with `--exclude`](#filtering-with---exclude)
+- [Using the library programmatically](#using-the-library-programmatically)
+- [Pointers](#pointers)
+
+## Getting an Nx graph dump
+
+Every command in this guide starts with a JSON file produced by Nx:
+
+```bash
+# Whole workspace:
+npx nx graph --file=graph.json
+
+# Only the projects affected by your branch (against develop):
+npx nx graph --affected --file=affected.json --base=origin/develop
+```
+
+`nx-mermaid-grapher` then reads that file and emits whichever format you ask
+for on stdout.
+
+## The four output formats
+
+Pick one with `-o <format>` (or `--format <format>`). The default is `mermaid`.
+
+### `mermaid` (default)
+
+**When to use it.** When the result is meant to be _seen_ — pasted into a PR
+description, a README, a Slack message that supports Mermaid, or shown back to
+a user by an AI assistant. Renders natively on GitHub/GitLab and in VS Code-
+based editors (Cursor, Windsurf, VSCodium, …) with a Mermaid preview extension.
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json
+```
+
+Output (a fenced ` ```mermaid ` block ready to paste into Markdown):
+
+````
+```mermaid
+graph LR
+  shared-infrastructure-nestjs-cqrs-events --> shared-domain
+  lending-infrastructure --> lending-application
+  lending-infrastructure --> shared-infrastructure-nestjs-cqrs-events
+  lending-infrastructure --> lending-domain
+  lending-infrastructure --> shared-domain
+  lending-application --> lending-domain
+  lending-application --> shared-domain
+  lending-application --> catalogue
+  lending-ui-rest --> lending-application
+  lending-ui-rest --> lending-domain
+  lending-ui-rest --> lending-infrastructure
+  lending-domain --> shared-domain
+  catalogue --> shared-domain
+  catalogue --> shared-infrastructure-nestjs-cqrs-events
+  library --> catalogue
+  library --> lending-ui-rest
+  library --> lending-domain
+  library --> lending-infrastructure
+```
+````
+
+Rendered, that looks like:
+
+```mermaid
+graph LR
+  shared-infrastructure-nestjs-cqrs-events --> shared-domain
+  lending-infrastructure --> lending-application
+  lending-infrastructure --> shared-infrastructure-nestjs-cqrs-events
+  lending-infrastructure --> lending-domain
+  lending-infrastructure --> shared-domain
+  lending-application --> lending-domain
+  lending-application --> shared-domain
+  lending-application --> catalogue
+  lending-ui-rest --> lending-application
+  lending-ui-rest --> lending-domain
+  lending-ui-rest --> lending-infrastructure
+  lending-domain --> shared-domain
+  catalogue --> shared-domain
+  catalogue --> shared-infrastructure-nestjs-cqrs-events
+  library --> catalogue
+  library --> lending-ui-rest
+  library --> lending-domain
+  library --> lending-infrastructure
+```
+
+If you want the body without the ` ```mermaid ` fence (e.g. you are wrapping it
+yourself or piping to another tool), add `--raw`:
+
+```bash
+npx nx-mermaid-grapher -f graph.json --raw
+```
+
+### `edges`
+
+**When to use it.** When you need a no-frills, token-cheap representation of
+the topology — for an LLM prompt, a `grep`/`awk` pipeline, or a quick diff.
+
+Each line is `source<space>target`. No header, no quoting, no trailing comma
+gymnastics. Isolated nodes (no outgoing edges) are not listed.
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -o edges
+```
+
+```
+shared-infrastructure-nestjs-cqrs-events shared-domain
+lending-infrastructure lending-application
+lending-infrastructure shared-infrastructure-nestjs-cqrs-events
+lending-infrastructure lending-domain
+lending-infrastructure shared-domain
+lending-application lending-domain
+lending-application shared-domain
+lending-application catalogue
+lending-ui-rest lending-application
+lending-ui-rest lending-domain
+lending-ui-rest lending-infrastructure
+lending-domain shared-domain
+catalogue shared-domain
+catalogue shared-infrastructure-nestjs-cqrs-events
+library catalogue
+library lending-ui-rest
+library lending-domain
+library lending-infrastructure
+```
+
+Quick recipes on top of this format:
+
+```bash
+# Direct dependents of `shared-domain`:
+nx-mermaid-grapher -f graph.json -o edges | awk '$2 == "shared-domain" { print $1 }'
+
+# Pure leaves (projects nothing else depends on):
+nx-mermaid-grapher -f graph.json -o edges \
+  | awk '{ targets[$2] = 1 } END { for (s in targets) if (!(s in seen)) print s }'
+```
+
+### `json`
+
+**When to use it.** When the consumer is code (a script, an AI tool, a custom
+visualiser) and you want a stable, structured shape. Single-line, compact JSON
+to keep token cost low. **Includes isolated nodes** so the topology can be
+reconstructed faithfully.
+
+Shape:
+
+```ts
+{
+  nodes: string[];          // every project, in declaration order
+  edges: [string, string][]; // [source, target] pairs
+}
+```
+
+Run:
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -o json
+```
+
+Compact output (one line, abbreviated here for readability):
+
+```json
+{"nodes":["shared-infrastructure-nestjs-cqrs-events","lending-infrastructure",
+"lending-application","lending-ui-rest","lending-domain","shared-domain",
+"catalogue","library"],"edges":[["shared-infrastructure-nestjs-cqrs-events",
+"shared-domain"],["lending-infrastructure","lending-application"], …]}
+```
+
+Pretty-printed for inspection (`… -o json | python3 -m json.tool` or `| jq`):
+
+```json
+{
+    "nodes": [
+        "shared-infrastructure-nestjs-cqrs-events",
+        "lending-infrastructure",
+        "lending-application",
+        "lending-ui-rest",
+        "lending-domain",
+        "shared-domain",
+        "catalogue",
+        "library"
+    ],
+    "edges": [
+        ["shared-infrastructure-nestjs-cqrs-events", "shared-domain"],
+        ["lending-infrastructure", "lending-application"],
+        ["lending-infrastructure", "shared-infrastructure-nestjs-cqrs-events"],
+        ["lending-infrastructure", "lending-domain"],
+        ["lending-infrastructure", "shared-domain"],
+        ["lending-application", "lending-domain"],
+        ["lending-application", "shared-domain"],
+        ["lending-application", "catalogue"],
+        ["lending-ui-rest", "lending-application"],
+        ["lending-ui-rest", "lending-domain"],
+        ["lending-ui-rest", "lending-infrastructure"],
+        ["lending-domain", "shared-domain"],
+        ["catalogue", "shared-domain"],
+        ["catalogue", "shared-infrastructure-nestjs-cqrs-events"],
+        ["library", "catalogue"],
+        ["library", "lending-ui-rest"],
+        ["library", "lending-domain"],
+        ["library", "lending-infrastructure"]
+    ]
+}
+```
+
+### `dot`
+
+**When to use it.** When you want an actual image (SVG/PNG) and have
+[Graphviz](https://graphviz.org/) installed.
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json -o dot
+```
+
+Output:
+
+```dot
+digraph G {
+  "shared-infrastructure-nestjs-cqrs-events";
+  "lending-infrastructure";
+  "lending-application";
+  "lending-ui-rest";
+  "lending-domain";
+  "shared-domain";
+  "catalogue";
+  "library";
+  "shared-infrastructure-nestjs-cqrs-events" -> "shared-domain";
+  "lending-infrastructure" -> "lending-application";
+  "lending-infrastructure" -> "shared-infrastructure-nestjs-cqrs-events";
+  "lending-infrastructure" -> "lending-domain";
+  "lending-infrastructure" -> "shared-domain";
+  "lending-application" -> "lending-domain";
+  "lending-application" -> "shared-domain";
+  "lending-application" -> "catalogue";
+  "lending-ui-rest" -> "lending-application";
+  "lending-ui-rest" -> "lending-domain";
+  "lending-ui-rest" -> "lending-infrastructure";
+  "lending-domain" -> "shared-domain";
+  "catalogue" -> "shared-domain";
+  "catalogue" -> "shared-infrastructure-nestjs-cqrs-events";
+  "library" -> "catalogue";
+  "library" -> "lending-ui-rest";
+  "library" -> "lending-domain";
+  "library" -> "lending-infrastructure";
+}
+```
+
+Render to an image:
+
+```bash
+npx nx-mermaid-grapher -f graph.json -o dot | dot -Tsvg > graph.svg
+npx nx-mermaid-grapher -f graph.json -o dot | dot -Tpng > graph.png
+```
+
+## Filtering with `--exclude`
+
+Any output format can be narrowed by excluding noisy projects. `-e` (or
+`--exclude`) is repeatable and removes the named project both as a source and
+as a target — so you don't end up with dangling arrows.
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json \
+  -e lending-infrastructure -e lending-ui-rest
+```
+
+This is especially useful for AI agent prompts: drop the projects the model
+doesn't care about before paying tokens for them.
+
+## Using the library programmatically
+
+Everything the CLI does is also exposed as a TypeScript API:
+
+```ts
+import {
+  DiGraph,
+  NXGraphFileLoader,
+  NxMermaidGrapher,
+  type OutputFormat,
+} from 'nx-mermaid-grapher';
+
+const core = new NxMermaidGrapher(new NXGraphFileLoader(), new DiGraph());
+core.init('graph.json');
+
+// Same as `--format mermaid`:
+const mermaid = core.getGraphSnippet();
+
+// Same as `--format json -e lending-infrastructure`:
+const compactJson = core.getGraphSnippet(['lending-infrastructure'], 'json');
+
+// Or call `formatGraph` directly if you already have a graph object:
+import { formatGraph } from 'nx-mermaid-grapher';
+const dot = formatGraph({ a: ['b'], b: [] }, 'dot');
+```
+
+You can also bring your own graph data structure by implementing `IGraph<T>`
+and passing it to `NxMermaidGrapher`. See the
+[Code section of the README](../README.md#code) for an example.
+
+## Pointers
+
+- [README](../README.md) — short overview, install, quick examples.
+- [Recipes in the README](../README.md#recipes) — affected-only graphs,
+  GitHub Actions PR comment workflow.
+- [`CHANGELOG.md`](../CHANGELOG.md) — release history.
+- [`SECURITY.md`](../SECURITY.md) — how to report vulnerabilities.

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -5,14 +5,15 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DiGraph } from './data-structures/di-graph.ds';
 import { isOutputFormat, OUTPUT_FORMATS } from './formatters';
-import { NXGraphFileLoader } from './nx/load-nx-graph';
+import { NXGraphFileLoader, STDIN_PATH } from './nx/load-nx-graph';
 import { NxMermaidGrapher } from './core';
 
-export const USAGE = `Usage: nx-mermaid-grapher -f <path> [-o <format>] [-e <lib>]... [--raw]
+export const USAGE = `Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [--raw]
 
 Options:
-  -f, --file <path>      NX graph output file
+  -f, --file <path>      NX graph output file. Pass \`-\` to read from stdin
                          (see: https://nx.dev/packages/nx/documents/dep-graph#file)
+      --stdin            Read the graph JSON from stdin (alias for \`-f -\`)
   -o, --format <format>  Output format (default: mermaid).
                          One of: ${OUTPUT_FORMATS.join(', ')}
   -e, --exclude <lib>    Exclude a library (repeatable)
@@ -49,6 +50,7 @@ export function run(argv: string[]): string {
       args: argv,
       options: {
         file: { type: 'string', short: 'f' },
+        stdin: { type: 'boolean' },
         format: { type: 'string', short: 'o' },
         exclude: { type: 'string', short: 'e', multiple: true },
         raw: { type: 'boolean' },
@@ -67,8 +69,12 @@ export function run(argv: string[]): string {
   if (values.help) return USAGE;
   if (values.version) return readVersion();
 
-  if (!values.file) {
-    throw new CliError('missing required option: -f, --file');
+  const inputPath = values.stdin ? STDIN_PATH : values.file;
+  if (!inputPath) {
+    throw new CliError('missing required option: -f, --file (or --stdin)');
+  }
+  if (values.stdin && values.file) {
+    throw new CliError('--stdin and -f/--file are mutually exclusive');
   }
 
   const format = values.format ?? 'mermaid';
@@ -77,7 +83,7 @@ export function run(argv: string[]): string {
   }
 
   const core = new NxMermaidGrapher(new NXGraphFileLoader(), new DiGraph());
-  core.init(values.file);
+  core.init(inputPath);
 
   const body = core.getGraphSnippet(values.exclude, format);
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -13,7 +13,8 @@ export const USAGE = `Usage: nx-mermaid-grapher -f <path> [-o <format>] [-e <lib
 Options:
   -f, --file <path>      NX graph output file
                          (see: https://nx.dev/packages/nx/documents/dep-graph#file)
-  -o, --format <format>  Output format: ${OUTPUT_FORMATS.join(' | ')} (default: mermaid)
+  -o, --format <format>  Output format (default: mermaid).
+                         One of: ${OUTPUT_FORMATS.join(', ')}
   -e, --exclude <lib>    Exclude a library (repeatable)
       --raw              Emit raw Mermaid (no \`\`\`mermaid markdown fence)
   -h, --help             Show help

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -4,17 +4,20 @@ import { parseArgs } from 'node:util';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DiGraph } from './data-structures/di-graph.ds';
+import { isOutputFormat, OUTPUT_FORMATS } from './formatters';
 import { NXGraphFileLoader } from './nx/load-nx-graph';
 import { NxMermaidGrapher } from './core';
 
-export const USAGE = `Usage: nx-mermaid-grapher -f <path> [-e <lib>]...
+export const USAGE = `Usage: nx-mermaid-grapher -f <path> [-o <format>] [-e <lib>]... [--raw]
 
 Options:
-  -f, --file <path>     NX graph output file
-                        (see: https://nx.dev/packages/nx/documents/dep-graph#file)
-  -e, --exclude <lib>   Exclude a library (repeatable)
-  -h, --help            Show help
-  -V, --version         Show version`;
+  -f, --file <path>      NX graph output file
+                         (see: https://nx.dev/packages/nx/documents/dep-graph#file)
+  -o, --format <format>  Output format: ${OUTPUT_FORMATS.join(' | ')} (default: mermaid)
+  -e, --exclude <lib>    Exclude a library (repeatable)
+      --raw              Emit raw Mermaid (no \`\`\`mermaid markdown fence)
+  -h, --help             Show help
+  -V, --version          Show version`;
 
 /**
  * Thrown for expected, user-facing CLI errors (bad/missing args).
@@ -45,7 +48,9 @@ export function run(argv: string[]): string {
       args: argv,
       options: {
         file: { type: 'string', short: 'f' },
+        format: { type: 'string', short: 'o' },
         exclude: { type: 'string', short: 'e', multiple: true },
+        raw: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
         version: { type: 'boolean', short: 'V' },
       },
@@ -65,10 +70,22 @@ export function run(argv: string[]): string {
     throw new CliError('missing required option: -f, --file');
   }
 
+  const format = values.format ?? 'mermaid';
+  if (!isOutputFormat(format)) {
+    throw new CliError(`invalid --format '${format}'. Choose one of: ${OUTPUT_FORMATS.join(', ')}`);
+  }
+
   const core = new NxMermaidGrapher(new NXGraphFileLoader(), new DiGraph());
   core.init(values.file);
 
-  return `\`\`\`mermaid\n${core.getGraphSnippet(values.exclude)}\`\`\``;
+  const body = core.getGraphSnippet(values.exclude, format);
+
+  // Wrap Mermaid output in a markdown code fence by default so users can paste
+  // it straight into a PR description or README. Use --raw to opt out.
+  if (format === 'mermaid' && !values.raw) {
+    return `\`\`\`mermaid\n${body}\`\`\``;
+  }
+  return body;
 }
 
 /* istanbul ignore next -- entry point, exercised via the integration smoke test */

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,5 +1,5 @@
-import { Edges, IGraph } from './data-structures/graph.ds.interface';
-import { formatGraph, OutputFormat } from './formatters';
+import { IGraph } from './data-structures/graph.ds.interface';
+import { excludeLibs, formatGraph, OutputFormat } from './formatters';
 import { GraphJsonResponse } from './nx/interfaces/graph-json.nx.interface';
 import { NXGraphFileLoader } from './nx/load-nx-graph';
 
@@ -17,7 +17,7 @@ export class NxMermaidGrapher {
   }
 
   getGraphSnippet(excludedLibs: string[] = [], format: OutputFormat = 'mermaid'): string {
-    const rs = this.filterOutLibs(this.graph.getGraph(), excludedLibs);
+    const rs = excludeLibs(this.graph.getGraph(), excludedLibs);
     return formatGraph(rs, format);
   }
 
@@ -31,21 +31,5 @@ export class NxMermaidGrapher {
         this.graph.addEdge(d.source, d.target);
       });
     });
-  }
-
-  private filterOutLibs(graphEdges: Edges<string>, excludedLibs: string[]) {
-    if (!excludedLibs.length) {
-      return graphEdges;
-    }
-
-    const excluded = new Set(excludedLibs);
-    const result: Edges<string> = {};
-
-    for (const [lib, deps] of Object.entries(graphEdges)) {
-      if (excluded.has(lib)) continue;
-      result[lib] = deps.filter((dep) => !excluded.has(dep));
-    }
-
-    return result;
   }
 }

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,4 +1,5 @@
 import { Edges, IGraph } from './data-structures/graph.ds.interface';
+import { formatGraph, OutputFormat } from './formatters';
 import { GraphJsonResponse } from './nx/interfaces/graph-json.nx.interface';
 import { NXGraphFileLoader } from './nx/load-nx-graph';
 
@@ -15,14 +16,9 @@ export class NxMermaidGrapher {
     this.toDiGraph();
   }
 
-  getGraphSnippet(excludedLibs: string[] = []) {
+  getGraphSnippet(excludedLibs: string[] = [], format: OutputFormat = 'mermaid'): string {
     const rs = this.filterOutLibs(this.graph.getGraph(), excludedLibs);
-
-    const lines = Object.keys(rs)
-      .filter((lib) => rs[lib].length)
-      .flatMap((lib) => rs[lib].map((dep) => `  ${lib} --> ${dep}\n`));
-
-    return `graph LR\n${lines.join('')}`;
+    return formatGraph(rs, format);
   }
 
   private toDiGraph(): void {

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -71,8 +71,14 @@ function formatEdges(edges: Edges<string>): string {
 }
 
 function formatJson(edges: Edges<string>): string {
-  const nodes = Object.keys(edges);
-  const edgeList: [string, string][] = nodes.flatMap((src) => edges[src].map((dst) => [src, dst] as [string, string]));
+  const ids = new Set<string>(Object.keys(edges));
+  for (const targets of Object.values(edges)) {
+    for (const dst of targets) ids.add(dst);
+  }
+  const nodes = [...ids];
+  const edgeList: [string, string][] = nodes.flatMap(
+    (src) => edges[src]?.map((dst) => [src, dst] as [string, string]) ?? [],
+  );
   return JSON.stringify({ nodes, edges: edgeList });
 }
 

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,0 +1,73 @@
+import { Edges } from './data-structures/graph.ds.interface';
+
+export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot';
+
+export const OUTPUT_FORMATS: readonly OutputFormat[] = ['mermaid', 'edges', 'json', 'dot'];
+
+export function isOutputFormat(value: string): value is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(value);
+}
+
+/**
+ * Render a dependency graph in the requested format.
+ *
+ * - `mermaid` — `graph LR` body with one edge per indented line. Isolated nodes
+ *   are omitted (they cannot be expressed as an edge).
+ * - `edges` — minimal whitespace-separated edge list, one `source target` pair
+ *   per line. Designed for cheap token consumption by AI agents.
+ * - `json` — `{ "nodes": [...], "edges": [["src", "dst"], ...] }`. Includes
+ *   isolated nodes so the topology can be reconstructed faithfully.
+ * - `dot` — Graphviz `digraph` declaration, ready to pipe into `dot -Tsvg`.
+ */
+export function formatGraph(edges: Edges<string>, format: OutputFormat): string {
+  switch (format) {
+    case 'mermaid':
+      return formatMermaid(edges);
+    case 'edges':
+      return formatEdges(edges);
+    case 'json':
+      return formatJson(edges);
+    case 'dot':
+      return formatDot(edges);
+  }
+}
+
+function withOutgoing(edges: Edges<string>): string[] {
+  return Object.keys(edges).filter((lib) => edges[lib].length > 0);
+}
+
+function formatMermaid(edges: Edges<string>): string {
+  const lines = withOutgoing(edges).flatMap((lib) =>
+    edges[lib].map((dep) => `  ${lib} --> ${dep}\n`),
+  );
+  return `graph LR\n${lines.join('')}`;
+}
+
+function formatEdges(edges: Edges<string>): string {
+  const lines = withOutgoing(edges).flatMap((lib) =>
+    edges[lib].map((dep) => `${lib} ${dep}\n`),
+  );
+  return lines.join('');
+}
+
+function formatJson(edges: Edges<string>): string {
+  const nodes = Object.keys(edges);
+  const edgeList: [string, string][] = nodes.flatMap((src) =>
+    edges[src].map((dst) => [src, dst] as [string, string]),
+  );
+  return JSON.stringify({ nodes, edges: edgeList });
+}
+
+function formatDot(edges: Edges<string>): string {
+  const lines: string[] = ['digraph G {'];
+  for (const node of Object.keys(edges)) {
+    lines.push(`  "${node}";`);
+  }
+  for (const src of withOutgoing(edges)) {
+    for (const dst of edges[src]) {
+      lines.push(`  "${src}" -> "${dst}";`);
+    }
+  }
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+}

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,6 +1,24 @@
 import { Edges } from './data-structures/graph.ds.interface';
 import { computeStats } from './stats';
 
+/**
+ * Return a copy of `graph` with the given libraries removed both as sources
+ * and as targets. Useful for trimming noise before rendering or computing
+ * stats — e.g. `formatGraph(excludeLibs(g, ['noisy-lib']), 'mermaid')`.
+ *
+ * Returns the input reference unchanged when `excluded` is empty.
+ */
+export function excludeLibs(graph: Edges<string>, excluded: readonly string[]): Edges<string> {
+  if (excluded.length === 0) return graph;
+  const blocklist = new Set(excluded);
+  const result: Edges<string> = {};
+  for (const [lib, deps] of Object.entries(graph)) {
+    if (blocklist.has(lib)) continue;
+    result[lib] = deps.filter((dep) => !blocklist.has(dep));
+  }
+  return result;
+}
+
 export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot' | 'stats';
 
 export const OUTPUT_FORMATS: readonly OutputFormat[] = ['mermaid', 'edges', 'json', 'dot', 'stats'];

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,8 +1,9 @@
 import { Edges } from './data-structures/graph.ds.interface';
+import { computeStats } from './stats';
 
-export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot';
+export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot' | 'stats';
 
-export const OUTPUT_FORMATS: readonly OutputFormat[] = ['mermaid', 'edges', 'json', 'dot'];
+export const OUTPUT_FORMATS: readonly OutputFormat[] = ['mermaid', 'edges', 'json', 'dot', 'stats'];
 
 export function isOutputFormat(value: string): value is OutputFormat {
   return (OUTPUT_FORMATS as readonly string[]).includes(value);
@@ -18,6 +19,9 @@ export function isOutputFormat(value: string): value is OutputFormat {
  * - `json` — `{ "nodes": [...], "edges": [["src", "dst"], ...] }`. Includes
  *   isolated nodes so the topology can be reconstructed faithfully.
  * - `dot` — Graphviz `digraph` declaration, ready to pipe into `dot -Tsvg`.
+ * - `stats` — human-readable summary (counts, roots/leaves, max depth, cycle
+ *   flag, per-project fan-in/fan-out). Designed for AI agents and humans who
+ *   want a single token-cheap snapshot of workspace shape.
  */
 export function formatGraph(edges: Edges<string>, format: OutputFormat): string {
   switch (format) {
@@ -29,6 +33,8 @@ export function formatGraph(edges: Edges<string>, format: OutputFormat): string 
       return formatJson(edges);
     case 'dot':
       return formatDot(edges);
+    case 'stats':
+      return formatStats(edges);
   }
 }
 
@@ -37,24 +43,18 @@ function withOutgoing(edges: Edges<string>): string[] {
 }
 
 function formatMermaid(edges: Edges<string>): string {
-  const lines = withOutgoing(edges).flatMap((lib) =>
-    edges[lib].map((dep) => `  ${lib} --> ${dep}\n`),
-  );
+  const lines = withOutgoing(edges).flatMap((lib) => edges[lib].map((dep) => `  ${lib} --> ${dep}\n`));
   return `graph LR\n${lines.join('')}`;
 }
 
 function formatEdges(edges: Edges<string>): string {
-  const lines = withOutgoing(edges).flatMap((lib) =>
-    edges[lib].map((dep) => `${lib} ${dep}\n`),
-  );
+  const lines = withOutgoing(edges).flatMap((lib) => edges[lib].map((dep) => `${lib} ${dep}\n`));
   return lines.join('');
 }
 
 function formatJson(edges: Edges<string>): string {
   const nodes = Object.keys(edges);
-  const edgeList: [string, string][] = nodes.flatMap((src) =>
-    edges[src].map((dst) => [src, dst] as [string, string]),
-  );
+  const edgeList: [string, string][] = nodes.flatMap((src) => edges[src].map((dst) => [src, dst] as [string, string]));
   return JSON.stringify({ nodes, edges: edgeList });
 }
 
@@ -69,5 +69,38 @@ function formatDot(edges: Edges<string>): string {
     }
   }
   lines.push('}');
+  return `${lines.join('\n')}\n`;
+}
+
+function formatStats(edges: Edges<string>): string {
+  const s = computeStats(edges);
+  const lines: string[] = ['graph stats'];
+  lines.push(`  nodes:     ${s.nodes}`);
+  lines.push(`  edges:     ${s.edges}`);
+
+  lines.push(`  roots:     ${s.roots.length}`);
+  for (const r of s.roots) lines.push(`    ${r}`);
+
+  lines.push(`  leaves:    ${s.leaves.length}`);
+  for (const l of s.leaves) lines.push(`    ${l}`);
+
+  lines.push(`  cycles:    ${s.hasCycles ? 'yes (max depth omitted)' : 'none'}`);
+
+  if (!s.hasCycles) {
+    lines.push(`  max depth: ${s.maxDepth}`);
+    if (s.longestPath) {
+      lines.push(`    ${s.longestPath.join(' -> ')}`);
+    }
+  }
+
+  if (s.projects.length > 0) {
+    lines.push('');
+    lines.push('per-project (fan-in / fan-out):');
+    const maxLen = Math.max(...s.projects.map((p) => p.name.length));
+    for (const p of s.projects) {
+      lines.push(`  ${p.name.padEnd(maxLen)}   ${p.fanIn} / ${p.fanOut}`);
+    }
+  }
+
   return `${lines.join('\n')}\n`;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,3 +2,4 @@ export { DiGraph } from './data-structures/di-graph.ds';
 export { NXGraphFileLoader } from './nx/load-nx-graph';
 export { NxMermaidGrapher } from './core';
 export { formatGraph, isOutputFormat, OUTPUT_FORMATS, type OutputFormat } from './formatters';
+export { computeStats, type GraphStats, type ProjectStats } from './stats';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export { DiGraph } from './data-structures/di-graph.ds';
 export { NXGraphFileLoader } from './nx/load-nx-graph';
 export { NxMermaidGrapher } from './core';
+export { formatGraph, isOutputFormat, OUTPUT_FORMATS, type OutputFormat } from './formatters';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 export { DiGraph } from './data-structures/di-graph.ds';
 export { NXGraphFileLoader } from './nx/load-nx-graph';
 export { NxMermaidGrapher } from './core';
-export { formatGraph, isOutputFormat, OUTPUT_FORMATS, type OutputFormat } from './formatters';
+export { excludeLibs, formatGraph, isOutputFormat, OUTPUT_FORMATS, type OutputFormat } from './formatters';
 export { computeStats, type GraphStats, type ProjectStats } from './stats';

--- a/lib/nx/load-nx-graph.ts
+++ b/lib/nx/load-nx-graph.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { GraphJsonResponse } from '../nx/interfaces/graph-json.nx.interface';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -21,16 +21,20 @@ function assertGraphJsonResponse(value: unknown, path: string): asserts value is
   }
 }
 
+/** Sentinel that tells `readNXGraph` to consume process.stdin instead of opening a file. */
+export const STDIN_PATH = '-';
+
 export class NXGraphFileLoader {
   private readFile(path: string): unknown {
     // Stryker disable next-line StringLiteral
-    const content = readFileSync(path, 'utf-8');
+    const content = path === STDIN_PATH ? readFileSync(0, 'utf-8') : readFileSync(path, 'utf-8');
     return JSON.parse(content);
   }
 
   readNXGraph(path: string): GraphJsonResponse {
     const value = this.readFile(path);
-    assertGraphJsonResponse(value, path);
+    const source = path === STDIN_PATH ? '<stdin>' : path;
+    assertGraphJsonResponse(value, source);
     return value;
   }
 }

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -41,7 +41,16 @@ export interface GraphStats {
  * dependency graphs comfortably larger than any real-world Nx workspace.
  */
 export function computeStats(graph: Edges<string>): GraphStats {
-  const nodes = Object.keys(graph);
+  // Build the node set from keys ∪ targets so we are robust to hand-rolled
+  // `Edges<string>` values where a dependency target was not declared as its
+  // own key. (The loader and `DiGraph` always declare targets, so this only
+  // matters for direct callers of the public API.)
+  const declared = new Set<string>(Object.keys(graph));
+  for (const targets of Object.values(graph)) {
+    for (const t of targets) declared.add(t);
+  }
+  const nodes = [...declared];
+
   const fanIn = new Map<string, number>();
   const fanOut = new Map<string, number>();
   for (const n of nodes) {
@@ -49,13 +58,9 @@ export function computeStats(graph: Edges<string>): GraphStats {
     fanOut.set(n, 0);
   }
 
-  // Invariant: every dependency target is also a declared node (the loader
-  // and `DiGraph` both ensure this), so we can index the maps without `??`
-  // fallbacks. If you pass a hand-rolled `Edges<string>` with dangling
-  // targets, declare them as keys with an empty array first.
   let edgeCount = 0;
   for (const src of nodes) {
-    const targets = graph[src];
+    const targets = graph[src] ?? [];
     fanOut.set(src, targets.length);
     edgeCount += targets.length;
     for (const dst of targets) {
@@ -84,7 +89,7 @@ export function computeStats(graph: Edges<string>): GraphStats {
     }
     color.set(n, GRAY);
     let best: { depth: number; path: string[] } = { depth: 0, path: [n] };
-    for (const child of graph[n]) {
+    for (const child of graph[n] ?? []) {
       const sub = dfs(child);
       if (sub.depth + 1 > best.depth) {
         best = { depth: sub.depth + 1, path: [n, ...sub.path] };

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,125 @@
+import { Edges } from './data-structures/graph.ds.interface';
+
+export interface ProjectStats {
+  name: string;
+  /** Number of edges pointing _at_ this project. */
+  fanIn: number;
+  /** Number of edges leaving this project. */
+  fanOut: number;
+}
+
+export interface GraphStats {
+  nodes: number;
+  edges: number;
+  /** Projects with no incoming edges (entry points). Sorted ascending. */
+  roots: string[];
+  /** Projects with no outgoing edges (pure leaves). Sorted ascending. */
+  leaves: string[];
+  /** True if the graph contains at least one directed cycle. */
+  hasCycles: boolean;
+  /**
+   * Number of edges in the longest dependency path. `null` when the graph
+   * contains a cycle (the concept is undefined in that case).
+   */
+  maxDepth: number | null;
+  /**
+   * One example of a longest path (sequence of node names). `null` when the
+   * graph has cycles, is empty, or has no edges.
+   */
+  longestPath: string[] | null;
+  /**
+   * All projects, sorted by `(fanIn desc, fanOut desc, name asc)` so the most
+   * "load-bearing" projects appear first.
+   */
+  projects: ProjectStats[];
+}
+
+/**
+ * Compute counts, hubs, and the longest dependency path for a graph.
+ *
+ * Runs in O(V + E). DFS is recursive; on Node 22 the default stack handles
+ * dependency graphs comfortably larger than any real-world Nx workspace.
+ */
+export function computeStats(graph: Edges<string>): GraphStats {
+  const nodes = Object.keys(graph);
+  const fanIn = new Map<string, number>();
+  const fanOut = new Map<string, number>();
+  for (const n of nodes) {
+    fanIn.set(n, 0);
+    fanOut.set(n, 0);
+  }
+
+  // Invariant: every dependency target is also a declared node (the loader
+  // and `DiGraph` both ensure this), so we can index the maps without `??`
+  // fallbacks. If you pass a hand-rolled `Edges<string>` with dangling
+  // targets, declare them as keys with an empty array first.
+  let edgeCount = 0;
+  for (const src of nodes) {
+    const targets = graph[src];
+    fanOut.set(src, targets.length);
+    edgeCount += targets.length;
+    for (const dst of targets) {
+      fanIn.set(dst, (fanIn.get(dst) as number) + 1);
+    }
+  }
+
+  const roots = nodes.filter((n) => fanIn.get(n) === 0).sort();
+  const leaves = nodes.filter((n) => fanOut.get(n) === 0).sort();
+
+  // DFS with three-colour cycle detection + memoised longest path.
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const n of nodes) color.set(n, WHITE);
+  const memo = new Map<string, { depth: number; path: string[] }>();
+  let hasCycles = false;
+
+  const dfs = (n: string): { depth: number; path: string[] } => {
+    const cached = memo.get(n);
+    if (cached) return cached;
+    if (color.get(n) === GRAY) {
+      hasCycles = true;
+      return { depth: 0, path: [n] };
+    }
+    color.set(n, GRAY);
+    let best: { depth: number; path: string[] } = { depth: 0, path: [n] };
+    for (const child of graph[n]) {
+      const sub = dfs(child);
+      if (sub.depth + 1 > best.depth) {
+        best = { depth: sub.depth + 1, path: [n, ...sub.path] };
+      }
+    }
+    color.set(n, BLACK);
+    memo.set(n, best);
+    return best;
+  };
+
+  let longest: { depth: number; path: string[] } = { depth: 0, path: [] };
+  for (const n of nodes) {
+    const result = dfs(n);
+    if (result.depth > longest.depth) longest = result;
+  }
+
+  const maxDepth = hasCycles ? null : longest.depth;
+  const longestPath = hasCycles || longest.depth === 0 ? null : longest.path;
+
+  const projects: ProjectStats[] = nodes
+    .map((n) => ({
+      name: n,
+      fanIn: fanIn.get(n) as number,
+      fanOut: fanOut.get(n) as number,
+    }))
+    .sort((a, b) => b.fanIn - a.fanIn || b.fanOut - a.fanOut || a.name.localeCompare(b.name));
+
+  return {
+    nodes: nodes.length,
+    edges: edgeCount,
+    roots,
+    leaves,
+    hasCycles,
+    maxDepth,
+    longestPath,
+    projects,
+  };
+}

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -40,4 +40,49 @@ describe('CLI run()', () => {
   it('throws CliError on unknown options', () => {
     expect(() => run(['--definitely-not-a-flag'])).toThrow(CliError);
   });
+
+  describe('--format / -o', () => {
+    it('emits raw mermaid (no markdown fence) with --raw', () => {
+      const out = run(['-f', FIXTURE, '--raw']);
+      expect(out.startsWith('graph LR\n')).toBe(true);
+      expect(out).not.toContain('```mermaid');
+    });
+
+    it('emits a plain edge list with --format edges', () => {
+      const out = run(['-f', FIXTURE, '-o', 'edges']);
+      expect(out).not.toContain('```');
+      expect(out).not.toContain('graph LR');
+      // Every non-empty line is `src dst` with no arrow noise.
+      const nonEmpty = out.split('\n').filter(Boolean);
+      expect(nonEmpty.length).toBeGreaterThan(0);
+      for (const line of nonEmpty) {
+        expect(line).toMatch(/^\S+ \S+$/);
+      }
+    });
+
+    it('emits parseable JSON with --format json', () => {
+      const out = run(['-f', FIXTURE, '--format', 'json']);
+      const parsed = JSON.parse(out);
+      expect(Array.isArray(parsed.nodes)).toBe(true);
+      expect(Array.isArray(parsed.edges)).toBe(true);
+      expect(parsed.nodes.length).toBeGreaterThan(0);
+      // Every edge is a [src, dst] pair of strings referring to declared nodes.
+      const nodeSet = new Set<string>(parsed.nodes);
+      for (const [src, dst] of parsed.edges) {
+        expect(nodeSet.has(src)).toBe(true);
+        expect(nodeSet.has(dst)).toBe(true);
+      }
+    });
+
+    it('emits a digraph with --format dot', () => {
+      const out = run(['-f', FIXTURE, '-o', 'dot']);
+      expect(out.startsWith('digraph G {\n')).toBe(true);
+      expect(out.trimEnd().endsWith('}')).toBe(true);
+      expect(out).toMatch(/"\S+" -> "\S+";/);
+    });
+
+    it('throws CliError for an unknown format', () => {
+      expect(() => run(['-f', FIXTURE, '-o', 'graphviz'])).toThrow(/invalid --format/);
+    });
+  });
 });

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -81,6 +81,15 @@ describe('CLI run()', () => {
       expect(out).toMatch(/"\S+" -> "\S+";/);
     });
 
+    it('emits a stats summary with --format stats', () => {
+      const out = run(['-f', FIXTURE, '-o', 'stats']);
+      expect(out.startsWith('graph stats\n')).toBe(true);
+      expect(out).toMatch(/nodes:\s+\d+/);
+      expect(out).toMatch(/edges:\s+\d+/);
+      expect(out).toMatch(/cycles:\s+(none|yes)/);
+      expect(out).toContain('per-project (fan-in / fan-out):');
+    });
+
     it('throws CliError for an unknown format', () => {
       expect(() => run(['-f', FIXTURE, '-o', 'graphviz'])).toThrow(/invalid --format/);
     });

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1,7 +1,33 @@
+// Wrap readFileSync in a jest.fn that delegates to the real implementation by
+// default, so individual tests can override it (e.g. to simulate stdin reads
+// from fd 0) without breaking unrelated reads.
+jest.mock('node:fs', () => {
+  const actual = jest.requireActual('node:fs');
+  return { ...actual, readFileSync: jest.fn(actual.readFileSync) };
+});
+
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CliError, run, USAGE } from '../lib/cli';
 
 const FIXTURE = join(__dirname, 'mocks', 'ddd-example.graph.json');
+const realReadFileSync = jest.requireActual('node:fs').readFileSync as typeof readFileSync;
+const FIXTURE_CONTENT = realReadFileSync(FIXTURE, 'utf-8') as string;
+const mockedReadFileSync = readFileSync as unknown as jest.MockedFunction<typeof readFileSync>;
+
+/** Have any read of fd 0 (stdin) return the bundled fixture content. */
+function withStdinFixture<T>(fn: () => T): T {
+  mockedReadFileSync.mockImplementation(((path: unknown, ...args: unknown[]) => {
+    if (path === 0) return FIXTURE_CONTENT;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (realReadFileSync as any)(path, ...args);
+  }) as typeof readFileSync);
+  try {
+    return fn();
+  } finally {
+    mockedReadFileSync.mockImplementation(realReadFileSync);
+  }
+}
 
 describe('CLI run()', () => {
   it('renders a Mermaid markdown block for a known fixture', () => {
@@ -32,9 +58,26 @@ describe('CLI run()', () => {
     expect(out).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it('throws CliError when -f is missing', () => {
+  it('throws CliError when neither -f nor --stdin is given', () => {
     expect(() => run([])).toThrow(CliError);
-    expect(() => run([])).toThrow(/missing required option/i);
+    expect(() => run([])).toThrow(/missing required option.*--stdin/i);
+  });
+
+  it('throws CliError when --stdin and -f are combined', () => {
+    expect(() => run(['--stdin', '-f', FIXTURE])).toThrow(/mutually exclusive/i);
+  });
+
+  describe('stdin input', () => {
+    it('reads the graph from stdin when --stdin is passed', () => {
+      const out = withStdinFixture(() => run(['--stdin']));
+      expect(out).toContain('graph LR\n');
+      expect(out).toContain('lending-infrastructure --> lending-application');
+    });
+
+    it('also accepts the idiomatic `-f -` form', () => {
+      const out = withStdinFixture(() => run(['-f', '-', '-o', 'edges']));
+      expect(out).toContain('lending-infrastructure lending-application');
+    });
   });
 
   it('throws CliError on unknown options', () => {

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -1,10 +1,5 @@
 import { Edges } from '../lib/data-structures/graph.ds.interface';
-import {
-  OUTPUT_FORMATS,
-  OutputFormat,
-  formatGraph,
-  isOutputFormat,
-} from '../lib/formatters';
+import { OUTPUT_FORMATS, OutputFormat, formatGraph, isOutputFormat } from '../lib/formatters';
 
 const SAMPLE: Edges<string> = {
   a: ['b', 'c'],
@@ -26,9 +21,7 @@ describe('isOutputFormat', () => {
 describe('formatGraph', () => {
   describe('mermaid', () => {
     it('emits a graph LR block with one indented edge per line', () => {
-      expect(formatGraph(SAMPLE, 'mermaid')).toBe(
-        'graph LR\n  a --> b\n  a --> c\n  b --> c\n',
-      );
+      expect(formatGraph(SAMPLE, 'mermaid')).toBe('graph LR\n  a --> b\n  a --> c\n  b --> c\n');
     });
 
     it('omits isolated nodes (no outgoing edges)', () => {
@@ -73,6 +66,38 @@ describe('formatGraph', () => {
       expect(out).toContain('  "c";'); // isolated node still declared
       expect(out).toContain('  "a" -> "b";');
       expect(out).toContain('  "b" -> "c";');
+    });
+  });
+
+  describe('stats', () => {
+    it('emits a readable summary block with the expected sections', () => {
+      const out = formatGraph(SAMPLE, 'stats');
+
+      expect(out.startsWith('graph stats\n')).toBe(true);
+      expect(out).toMatch(/nodes:\s+3/);
+      expect(out).toMatch(/edges:\s+3/);
+      expect(out).toMatch(/roots:\s+1/);
+      expect(out).toMatch(/leaves:\s+1/);
+      expect(out).toMatch(/cycles:\s+none/);
+      expect(out).toMatch(/max depth:\s+2/);
+      expect(out).toContain('a -> b -> c');
+      expect(out).toContain('per-project (fan-in / fan-out):');
+      // Node `c` is the most depended-on, so it lists first.
+      const perProject = out.split('per-project (fan-in / fan-out):\n')[1];
+      expect(perProject.trimStart().startsWith('c ')).toBe(true);
+    });
+
+    it('omits the per-project section for an empty graph', () => {
+      const out = formatGraph({}, 'stats');
+      expect(out).toMatch(/nodes:\s+0/);
+      expect(out).toMatch(/edges:\s+0/);
+      expect(out).not.toContain('per-project');
+    });
+
+    it('flags cycles and omits max depth', () => {
+      const out = formatGraph({ a: ['b'], b: ['a'] }, 'stats');
+      expect(out).toMatch(/cycles:\s+yes/);
+      expect(out).not.toContain('max depth:');
     });
   });
 

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -1,5 +1,5 @@
 import { Edges } from '../lib/data-structures/graph.ds.interface';
-import { OUTPUT_FORMATS, OutputFormat, formatGraph, isOutputFormat } from '../lib/formatters';
+import { OUTPUT_FORMATS, OutputFormat, excludeLibs, formatGraph, isOutputFormat } from '../lib/formatters';
 
 const SAMPLE: Edges<string> = {
   a: ['b', 'c'],
@@ -105,5 +105,28 @@ describe('formatGraph', () => {
     for (const fmt of OUTPUT_FORMATS) {
       expect(typeof formatGraph(SAMPLE, fmt as OutputFormat)).toBe('string');
     }
+  });
+});
+
+describe('excludeLibs', () => {
+  it('returns the input reference unchanged when no libs are excluded', () => {
+    expect(excludeLibs(SAMPLE, [])).toBe(SAMPLE);
+  });
+
+  it('drops the excluded libs as both sources and targets', () => {
+    const out = excludeLibs(SAMPLE, ['b']);
+    expect(out).toEqual({ a: ['c'], c: [] });
+    // Original is untouched.
+    expect(SAMPLE).toEqual({ a: ['b', 'c'], b: ['c'], c: [] });
+  });
+
+  it('handles multiple exclusions and never leaves dangling edges', () => {
+    const out = excludeLibs(SAMPLE, ['b', 'c']);
+    expect(out).toEqual({ a: [] });
+  });
+
+  it('composes with formatGraph for AI-agent style filtering', () => {
+    const out = formatGraph(excludeLibs(SAMPLE, ['b']), 'edges');
+    expect(out).toBe('a c\n');
   });
 });

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -1,0 +1,84 @@
+import { Edges } from '../lib/data-structures/graph.ds.interface';
+import {
+  OUTPUT_FORMATS,
+  OutputFormat,
+  formatGraph,
+  isOutputFormat,
+} from '../lib/formatters';
+
+const SAMPLE: Edges<string> = {
+  a: ['b', 'c'],
+  b: ['c'],
+  c: [], // isolated (no outgoing edges)
+};
+
+describe('isOutputFormat', () => {
+  it.each(OUTPUT_FORMATS)('accepts %s', (fmt) => {
+    expect(isOutputFormat(fmt)).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(isOutputFormat('graphviz')).toBe(false);
+    expect(isOutputFormat('')).toBe(false);
+  });
+});
+
+describe('formatGraph', () => {
+  describe('mermaid', () => {
+    it('emits a graph LR block with one indented edge per line', () => {
+      expect(formatGraph(SAMPLE, 'mermaid')).toBe(
+        'graph LR\n  a --> b\n  a --> c\n  b --> c\n',
+      );
+    });
+
+    it('omits isolated nodes (no outgoing edges)', () => {
+      expect(formatGraph({ orphan: [] }, 'mermaid')).toBe('graph LR\n');
+    });
+  });
+
+  describe('edges', () => {
+    it('emits a plain "src dst" line per edge', () => {
+      expect(formatGraph(SAMPLE, 'edges')).toBe('a b\na c\nb c\n');
+    });
+
+    it('produces empty output when there are no edges', () => {
+      expect(formatGraph({ orphan: [] }, 'edges')).toBe('');
+    });
+  });
+
+  describe('json', () => {
+    it('emits compact JSON with the full node list (incl. isolated) and edge pairs', () => {
+      const out = JSON.parse(formatGraph(SAMPLE, 'json'));
+      expect(out).toEqual({
+        nodes: ['a', 'b', 'c'],
+        edges: [
+          ['a', 'b'],
+          ['a', 'c'],
+          ['b', 'c'],
+        ],
+      });
+    });
+
+    it('is single-line (compact) so it is cheap to consume', () => {
+      expect(formatGraph(SAMPLE, 'json')).not.toContain('\n');
+    });
+  });
+
+  describe('dot', () => {
+    it('emits a digraph declaration with quoted nodes and edges', () => {
+      const out = formatGraph(SAMPLE, 'dot');
+      expect(out.startsWith('digraph G {\n')).toBe(true);
+      expect(out.trimEnd().endsWith('}')).toBe(true);
+      expect(out).toContain('  "a";');
+      expect(out).toContain('  "c";'); // isolated node still declared
+      expect(out).toContain('  "a" -> "b";');
+      expect(out).toContain('  "b" -> "c";');
+    });
+  });
+
+  it('is exhaustive over OUTPUT_FORMATS (no format silently falls through)', () => {
+    for (const fmt of OUTPUT_FORMATS) {
+      expect(typeof formatGraph(SAMPLE, fmt as OutputFormat)).toBe('string');
+    }
+  });
+});

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -55,6 +55,14 @@ describe('formatGraph', () => {
     it('is single-line (compact) so it is cheap to consume', () => {
       expect(formatGraph(SAMPLE, 'json')).not.toContain('\n');
     });
+
+    it('includes nodes that are only targets and never sources', () => {
+      const out = formatGraph({ a: ['b'] }, 'json');
+      const parsed = JSON.parse(out) as { nodes: string[]; edges: [string, string][] };
+      expect(parsed.nodes).toContain('a');
+      expect(parsed.nodes).toContain('b');
+      expect(parsed.edges).toEqual([['a', 'b']]);
+    });
   });
 
   describe('dot', () => {

--- a/tests/nx/load-nx-graph.spec.ts
+++ b/tests/nx/load-nx-graph.spec.ts
@@ -1,7 +1,7 @@
-jest.mock('fs');
+jest.mock('node:fs');
 import mockGraphExample from '../mocks/ddd-example.graph.json';
 import { NXGraphFileLoader } from '../../lib/nx/load-nx-graph';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 
 describe('NXGraphFileLoader', () => {
   let loader: NXGraphFileLoader;
@@ -15,7 +15,20 @@ describe('NXGraphFileLoader', () => {
 
     expect(loader.readNXGraph('path')).toBeTruthy();
 
-    expect(readFileSync).toHaveBeenCalled();
+    expect(readFileSync).toHaveBeenCalledWith('path', 'utf-8');
+  });
+
+  it('reads from stdin (fd 0) when path is "-"', () => {
+    (readFileSync as jest.Mock).mockReturnValue(JSON.stringify(mockGraphExample));
+
+    expect(loader.readNXGraph('-')).toBeTruthy();
+
+    expect(readFileSync).toHaveBeenCalledWith(0, 'utf-8');
+  });
+
+  it('labels stdin errors with "<stdin>" instead of "-"', () => {
+    (readFileSync as jest.Mock).mockReturnValue('{}');
+    expect(() => loader.readNXGraph('-')).toThrow(/^<stdin>:/);
   });
 
   it.each([

--- a/tests/stats.spec.ts
+++ b/tests/stats.spec.ts
@@ -87,6 +87,28 @@ describe('computeStats', () => {
     expect(s.projects.map((p) => p.name)).toEqual(['c', 'b', 'a']);
   });
 
+  it('handles hand-rolled graphs whose targets are not declared as keys', () => {
+    // `b` and `c` only exist as edge targets — never declared with their own
+    // key. Public-API callers shouldn't crash or get NaN counts.
+    const g = { a: ['b', 'c'] } as Edges<string>;
+    const s = computeStats(g);
+
+    expect(s.nodes).toBe(3);
+    expect(s.edges).toBe(2);
+    expect(s.roots).toEqual(['a']);
+    expect(s.leaves.sort()).toEqual(['b', 'c']);
+    expect(s.hasCycles).toBe(false);
+    expect(s.maxDepth).toBe(1);
+
+    const fan = Object.fromEntries(s.projects.map((p) => [p.name, [p.fanIn, p.fanOut]]));
+    expect(fan).toEqual({ a: [0, 2], b: [1, 0], c: [1, 0] });
+    // No NaN sneaking into any count:
+    for (const p of s.projects) {
+      expect(Number.isFinite(p.fanIn)).toBe(true);
+      expect(Number.isFinite(p.fanOut)).toBe(true);
+    }
+  });
+
   it('produces a stable per-project order for ties (name ascending)', () => {
     const g: Edges<string> = { z: ['x'], y: ['x'], x: [] };
     const s = computeStats(g);

--- a/tests/stats.spec.ts
+++ b/tests/stats.spec.ts
@@ -1,0 +1,97 @@
+import { Edges } from '../lib/data-structures/graph.ds.interface';
+import { computeStats } from '../lib/stats';
+
+describe('computeStats', () => {
+  it('handles an empty graph', () => {
+    const s = computeStats({});
+    expect(s).toEqual({
+      nodes: 0,
+      edges: 0,
+      roots: [],
+      leaves: [],
+      hasCycles: false,
+      maxDepth: 0,
+      longestPath: null,
+      projects: [],
+    });
+  });
+
+  it('treats an isolated node as both a root and a leaf with depth 0', () => {
+    const s = computeStats({ a: [] });
+    expect(s.nodes).toBe(1);
+    expect(s.edges).toBe(0);
+    expect(s.roots).toEqual(['a']);
+    expect(s.leaves).toEqual(['a']);
+    expect(s.maxDepth).toBe(0);
+    expect(s.longestPath).toBeNull();
+    expect(s.hasCycles).toBe(false);
+  });
+
+  it('computes counts, fan-in/out, and the longest path on a linear chain', () => {
+    // a -> b -> c -> d
+    const g: Edges<string> = { a: ['b'], b: ['c'], c: ['d'], d: [] };
+    const s = computeStats(g);
+
+    expect(s.nodes).toBe(4);
+    expect(s.edges).toBe(3);
+    expect(s.roots).toEqual(['a']);
+    expect(s.leaves).toEqual(['d']);
+    expect(s.hasCycles).toBe(false);
+    expect(s.maxDepth).toBe(3);
+    expect(s.longestPath).toEqual(['a', 'b', 'c', 'd']);
+
+    const fan = Object.fromEntries(s.projects.map((p) => [p.name, [p.fanIn, p.fanOut]]));
+    expect(fan).toEqual({ a: [0, 1], b: [1, 1], c: [1, 1], d: [1, 0] });
+  });
+
+  it('finds the longest path through a diamond (a->b->d, a->c->d)', () => {
+    const g: Edges<string> = { a: ['b', 'c'], b: ['d'], c: ['d'], d: [] };
+    const s = computeStats(g);
+
+    expect(s.maxDepth).toBe(2);
+    // Either route is acceptable; we only care that it's a real depth-2 path.
+    expect(s.longestPath?.[0]).toBe('a');
+    expect(s.longestPath?.[s.longestPath.length - 1]).toBe('d');
+    expect(s.longestPath).toHaveLength(3);
+    expect(s.roots).toEqual(['a']);
+    expect(s.leaves).toEqual(['d']);
+  });
+
+  it('detects cycles and reports null max depth', () => {
+    // a -> b -> a
+    const g: Edges<string> = { a: ['b'], b: ['a'] };
+    const s = computeStats(g);
+
+    expect(s.hasCycles).toBe(true);
+    expect(s.maxDepth).toBeNull();
+    expect(s.longestPath).toBeNull();
+    // Neither node has fan-in 0 → no roots; same for leaves.
+    expect(s.roots).toEqual([]);
+    expect(s.leaves).toEqual([]);
+  });
+
+  it('detects a self-loop as a cycle', () => {
+    const g: Edges<string> = { a: ['a'] };
+    const s = computeStats(g);
+    expect(s.hasCycles).toBe(true);
+    expect(s.maxDepth).toBeNull();
+  });
+
+  it('sorts projects by fan-in desc, then fan-out desc, then name asc', () => {
+    // a -> b -> c, a -> c
+    //   a: fanIn=0, fanOut=2
+    //   b: fanIn=1, fanOut=1
+    //   c: fanIn=2, fanOut=0  <- highest fan-in, comes first
+    const g: Edges<string> = { a: ['b', 'c'], b: ['c'], c: [] };
+    const s = computeStats(g);
+    expect(s.projects.map((p) => p.name)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('produces a stable per-project order for ties (name ascending)', () => {
+    const g: Edges<string> = { z: ['x'], y: ['x'], x: [] };
+    const s = computeStats(g);
+    // y and z both have fanIn=0, fanOut=1 → tied → sorted by name asc.
+    const namesAfterX = s.projects.slice(1).map((p) => p.name);
+    expect(namesAfterX).toEqual(['y', 'z']);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read graph JSON from stdin (`--stdin` / `-f -`), choose output format (`--format`) and strip Mermaid fences (`--raw`)
  * New output formats: mermaid, edges, json, dot, stats
  * New public API for formatting, stats, and excluding libs (for programmatic use)

* **Documentation**
  * Expanded README and added a detailed usage guide with examples and format comparisons

* **Tests**
  * Added/expanded tests covering stdin, formats, exclusion, and stats calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nx-mermaid-grapher/pull/30)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->