### PR TITLE
feat(cli): add `-p, --projects` flag for affected-project subgraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowlist filtering logic so programmatic callers can compose it with
   `formatGraph` and `computeStats` (e.g. `formatGraph(selectLibs(graph, affected), 'mermaid')`).
 
+### Deprecated
+
+- `NxMermaidGrapher.getGraphSnippet()` parameter order. The current signature
+  places `selectedLibraries` after `format`, forcing callers to always pass
+  `format` when they only want to filter by selected libraries.
+
 ### Fixed
 
 - Rewrote affected-project recipe. Corrects the false claim that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-p, --projects <lib>` CLI flag** (repeatable) to render only the specified
+  libraries and edges between them. Ideal for affected-project subgraphs when
+  you already know which projects changed (e.g. from `nx show projects --affected`).
+  Composes with `-e` / `--exclude` — exclusion runs first, then the allowlist.
+- Public export `selectLibs(graph, selected)` from `lib/formatters`. Lifts the
+  allowlist filtering logic so programmatic callers can compose it with
+  `formatGraph` and `computeStats` (e.g. `formatGraph(selectLibs(graph, affected), 'mermaid')`).
+
+### Fixed
+
+- Rewrote affected-project recipe. Corrects the false claim that
+  `nx graph --affected --file=...` outputs an affected-only JSON. The proper
+  workflow is: `nx graph --file=...` + `nx show projects --affected --json`
+  piped through `jq` to build `-p` flags.
+- Updated GitHub Actions workflow example to use the same correct approach.
+
 ## [2.0.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npx nx-mermaid-grapher -f file.json
 Then, run it with `-f [PATH]` or `--file [PATH]` parameter providing the path for your NX graph JSON output file.
 
 ```
-Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [--raw]
+Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [--raw]
 
 Options:
   -f, --file <path>      NX graph output file. Pass `-` to read from stdin
@@ -115,6 +115,8 @@ Options:
   -o, --format <format>  Output format (default: mermaid).
                          One of: mermaid, edges, json, dot, stats
   -e, --exclude <lib>    Exclude a library (repeatable)
+  -p, --projects <lib>   Include only these libraries (repeatable).
+                         Useful for rendering affected-project subgraphs.
       --raw              Emit raw Mermaid (no ```mermaid markdown fence)
   -h, --help             Show help
   -V, --version          Show version
@@ -261,19 +263,28 @@ const core = new NxMermaidGrapher(loader, myGraph);
 
 ### Render only the libs affected by a PR
 
-`nx graph` can produce an _affected-only_ subset of the workspace graph as JSON,
-which `nx-mermaid-grapher` consumes as-is. Two commands are all you need:
+> **Note:** `nx graph --affected --file=affected.json` does **not** produce a
+> JSON dump that contains only the affected projects. It outputs the full
+> workspace graph (the `--affected` flag was historically used for the browser
+> UI only). The `affectedProjects` field in the JSON was deprecated and
+> removed in Nx 19.1.1 (see [nrwl/nx#26501](https://github.com/nrwl/nx/issues/26501)).
+>
+> To get an actual affected-only subgraph, combine the two commands below:
 
 ```bash
-# 1. Generate JSON for the projects affected against your target branch.
-npx nx graph --affected --file=affected.json --base=origin/develop
+# 1. Dump the *full* workspace graph (once).
+npx nx graph --file=graph.json
 
-# 2. Convert it into a Mermaid block ready to paste into a PR description.
-npx nx-mermaid-grapher -f affected.json
+# 2. Get the names of affected projects and render only those.
+#    Requires `jq`; adjust --base to your target branch.
+npx nx-mermaid-grapher -f graph.json \
+  $(npx nx show projects --affected --json --base=origin/develop \
+    | jq -r '.[] | "-p " + .')
 ```
 
 You can swap `--base=origin/develop` for `origin/main` (or any commit-ish) and
-combine with `-e <lib>` to hide noisy projects from the rendered graph.
+still combine with `-e <lib>` to hide noisy projects in addition to the
+affected filter.
 
 ### Auto-post the affected graph as a PR comment (GitHub Actions)
 
@@ -309,11 +320,17 @@ jobs:
 
       - name: Generate affected Mermaid graph
         run: |
-          npx nx graph --affected --file=affected.json --base=origin/${{ github.base_ref }}
+          # 1. Dump the full workspace graph.
+          npx nx graph --file=graph.json
+
+          # 2. Get affected project names and build -p flags.
+          PROJECTS=$(npx nx show projects --affected --json --base=origin/${{ github.base_ref }} | jq -r '.[] | "-p " + .' | xargs)
+
+          # 3. Render the subgraph.
           {
             echo '## Affected dependency graph'
             echo
-            npx nx-mermaid-grapher -f affected.json
+            npx nx-mermaid-grapher -f graph.json $PROJECTS
           } > graph.md
 
       - name: Comment on the PR

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -11,16 +11,18 @@ wiring it into a script, an AI agent prompt, or a CI workflow.
 
 ## Table of contents
 
-- [Getting an Nx graph dump](#getting-an-nx-graph-dump)
-- [The output formats](#the-output-formats)
-  - [`mermaid` (default)](#mermaid-default)
-  - [`edges`](#edges)
-  - [`json`](#json)
-  - [`dot`](#dot)
-  - [`stats`](#stats)
-- [Filtering with `--exclude`](#filtering-with---exclude)
-- [Using the library programmatically](#using-the-library-programmatically)
-- [Pointers](#pointers)
+- [Usage guide](#usage-guide)
+  - [Table of contents](#table-of-contents)
+  - [Getting an Nx graph dump](#getting-an-nx-graph-dump)
+  - [The output formats](#the-output-formats)
+    - [`mermaid` (default)](#mermaid-default)
+    - [`edges`](#edges)
+    - [`json`](#json)
+    - [`dot`](#dot)
+    - [`stats`](#stats)
+  - [Filtering with `--exclude` and `--projects`](#filtering-with---exclude-and---projects)
+  - [Using the library programmatically](#using-the-library-programmatically)
+  - [Pointers](#pointers)
 
 ## Getting an Nx graph dump
 
@@ -29,9 +31,6 @@ Every command in this guide starts with a JSON file produced by Nx:
 ```bash
 # Whole workspace:
 npx nx graph --file=graph.json
-
-# Only the projects affected by your branch (against develop):
-npx nx graph --affected --file=affected.json --base=origin/develop
 ```
 
 `nx-mermaid-grapher` then reads that file and emits whichever format you ask
@@ -329,7 +328,7 @@ The format is plain text by design (cheap for both humans and LLMs to skim).
 If you need it as structured data, call [`computeStats`](#using-the-library-programmatically)
 from the library API instead — it returns a typed `GraphStats` object.
 
-## Filtering with `--exclude`
+## Filtering with `--exclude` and `--projects`
 
 Any output format can be narrowed by excluding noisy projects. `-e` (or
 `--exclude`) is repeatable and removes the named project both as a source and
@@ -342,6 +341,18 @@ npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json \
 
 This is especially useful for AI agent prompts: drop the projects the model
 doesn't care about before paying tokens for them.
+
+To keep only a specific set of libraries, use `-p` (or `--projects`). This is
+ideal for rendering affected-project subgraphs when you already know which
+projects changed:
+
+```bash
+npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json \
+  -p lending-infrastructure -p lending-application -p lending-domain
+```
+
+The two flags compose: `--exclude` runs first, then `--projects` filters the
+remaining graph. You can combine them for precise control.
 
 ## Using the library programmatically
 
@@ -375,10 +386,14 @@ const stats: GraphStats = computeStats({ a: ['b', 'c'], b: ['c'], c: [] });
 //     maxDepth: 2, longestPath: ['a', 'b', 'c'], projects: [...] }
 
 // Need stats or a rendered graph with some libs filtered out? Compose
-// `excludeLibs` with either:
-import { excludeLibs } from 'nx-mermaid-grapher';
+// `excludeLibs` or `selectLibs` with either:
+import { excludeLibs, selectLibs } from 'nx-mermaid-grapher';
 const trimmedStats = computeStats(excludeLibs(graph, ['noisy-lib']));
 const trimmedDot = formatGraph(excludeLibs(graph, ['noisy-lib']), 'dot');
+
+// Or render only the projects affected by your PR:
+const affected = selectLibs(graph, ['lending-infrastructure', 'lending-application']);
+const affectedMermaid = formatGraph(affected, 'mermaid');
 ```
 
 You can also bring your own graph data structure by implementing `IGraph<T>`

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -8,7 +8,7 @@ import { isOutputFormat, OUTPUT_FORMATS } from './formatters';
 import { NXGraphFileLoader, STDIN_PATH } from './nx/load-nx-graph';
 import { NxMermaidGrapher } from './core';
 
-export const USAGE = `Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [--raw]
+export const USAGE = `Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [--raw]
 
 Options:
   -f, --file <path>      NX graph output file. Pass \`-\` to read from stdin
@@ -17,6 +17,8 @@ Options:
   -o, --format <format>  Output format (default: mermaid).
                          One of: ${OUTPUT_FORMATS.join(', ')}
   -e, --exclude <lib>    Exclude a library (repeatable)
+  -p, --projects <lib>   Include only these libraries (repeatable).
+                         Useful for rendering affected-project subgraphs.
       --raw              Emit raw Mermaid (no \`\`\`mermaid markdown fence)
   -h, --help             Show help
   -V, --version          Show version`;
@@ -53,6 +55,7 @@ export function run(argv: string[]): string {
         stdin: { type: 'boolean' },
         format: { type: 'string', short: 'o' },
         exclude: { type: 'string', short: 'e', multiple: true },
+        projects: { type: 'string', short: 'p', multiple: true },
         raw: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
         version: { type: 'boolean', short: 'V' },
@@ -85,7 +88,8 @@ export function run(argv: string[]): string {
   const core = new NxMermaidGrapher(new NXGraphFileLoader(), new DiGraph());
   core.init(inputPath);
 
-  const body = core.getGraphSnippet(values.exclude, format);
+  const selected = values.projects?.length ? values.projects : undefined;
+  const body = core.getGraphSnippet(values.exclude, format, selected);
 
   // Wrap Mermaid output in a markdown code fence by default so users can paste
   // it straight into a PR description or README. Use --raw to opt out.

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -16,6 +16,12 @@ export class NxMermaidGrapher {
     this.toDiGraph();
   }
 
+  /**
+   * @deprecated Parameter order will be stabilized as `(excludedLibs, selectedLibraries, format)`
+   * in the next major version.
+   *
+   * See: https://github.com/Fcmam5/nx-mermaid-grapher/issues/33
+   */
   getGraphSnippet(excludedLibs: string[] = [], format: OutputFormat = 'mermaid', selectedLibraries?: string[]): string {
     let rs = excludeLibs(this.graph.getGraph(), excludedLibs);
     if (selectedLibraries) {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,5 +1,5 @@
 import { IGraph } from './data-structures/graph.ds.interface';
-import { excludeLibs, formatGraph, OutputFormat } from './formatters';
+import { excludeLibs, formatGraph, OutputFormat, selectLibs } from './formatters';
 import { GraphJsonResponse } from './nx/interfaces/graph-json.nx.interface';
 import { NXGraphFileLoader } from './nx/load-nx-graph';
 
@@ -16,8 +16,11 @@ export class NxMermaidGrapher {
     this.toDiGraph();
   }
 
-  getGraphSnippet(excludedLibs: string[] = [], format: OutputFormat = 'mermaid'): string {
-    const rs = excludeLibs(this.graph.getGraph(), excludedLibs);
+  getGraphSnippet(excludedLibs: string[] = [], format: OutputFormat = 'mermaid', selectedLibraries?: string[]): string {
+    let rs = excludeLibs(this.graph.getGraph(), excludedLibs);
+    if (selectedLibraries) {
+      rs = selectLibs(rs, selectedLibraries);
+    }
     return formatGraph(rs, format);
   }
 

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -19,6 +19,24 @@ export function excludeLibs(graph: Edges<string>, excluded: readonly string[]): 
   return result;
 }
 
+/**
+ * Return a copy of `graph` containing only the given libraries and edges
+ * where both endpoints are in the allowlist. Useful for focusing on a subset
+ * of projects — e.g. affected projects from `nx show projects --affected`.
+ *
+ * Returns the input reference unchanged when `libraries` is empty.
+ */
+export function selectLibs(graph: Edges<string>, libraries: readonly string[]): Edges<string> {
+  if (libraries.length === 0) return graph;
+  const allowlist = new Set(libraries);
+  const result: Edges<string> = {};
+  for (const [lib, deps] of Object.entries(graph)) {
+    if (!allowlist.has(lib)) continue;
+    result[lib] = deps.filter((dep) => allowlist.has(dep));
+  }
+  return result;
+}
+
 export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot' | 'stats';
 
 export const OUTPUT_FORMATS: readonly OutputFormat[] = ['mermaid', 'edges', 'json', 'dot', 'stats'];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 export { DiGraph } from './data-structures/di-graph.ds';
 export { NXGraphFileLoader } from './nx/load-nx-graph';
 export { NxMermaidGrapher } from './core';
-export { excludeLibs, formatGraph, isOutputFormat, OUTPUT_FORMATS, type OutputFormat } from './formatters';
+export { excludeLibs, formatGraph, isOutputFormat, selectLibs, OUTPUT_FORMATS, type OutputFormat } from './formatters';
 export { computeStats, type GraphStats, type ProjectStats } from './stats';

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -48,6 +48,15 @@ describe('CLI run()', () => {
     expect(out).not.toMatch(new RegExp(`--> ${excluded}(\\n|$)`));
   });
 
+  it('honours --projects (repeatable) by keeping only the specified libs', () => {
+    const out = run(['-f', FIXTURE, '-p', 'lending-infrastructure', '-p', 'lending-application']);
+
+    expect(out).toContain('lending-infrastructure --> lending-application');
+    expect(out).not.toContain('lending-domain');
+    expect(out).not.toContain('catalogue');
+    expect(out).not.toContain('library');
+  });
+
   it('returns USAGE for --help', () => {
     expect(run(['--help'])).toBe(USAGE);
     expect(run(['-h'])).toBe(USAGE);

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -80,6 +80,30 @@ describe('Library core', () => {
     it('should get a graph without excluded head library', () => {
       expect(coreCls.getGraphSnippet(['library'])).toEqual(expectedGraphWithoutHeadLib);
     });
+
+    it('should get a graph with only selected libraries', () => {
+      const out = coreCls.getGraphSnippet([], 'mermaid', [
+        'lending-infrastructure',
+        'lending-application',
+        'lending-domain',
+      ]);
+      expect(out).toContain('lending-infrastructure --> lending-application');
+      expect(out).toContain('lending-application --> lending-domain');
+      expect(out).not.toContain('catalogue');
+      expect(out).not.toContain('library');
+      expect(out).not.toContain('shared-infrastructure-nestjs-cqrs-events');
+    });
+
+    it('should compose exclude and selectLibs for affected-project filtering', () => {
+      const out = coreCls.getGraphSnippet(['library'], 'mermaid', [
+        'lending-infrastructure',
+        'lending-application',
+        'lending-domain',
+      ]);
+      expect(out).toContain('lending-infrastructure --> lending-application');
+      expect(out).not.toContain('library');
+      expect(out).not.toContain('catalogue');
+    });
   });
 
   describe('.getGraphSnippetForLib', () => {

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -1,5 +1,5 @@
 import { Edges } from '../lib/data-structures/graph.ds.interface';
-import { OUTPUT_FORMATS, OutputFormat, excludeLibs, formatGraph, isOutputFormat } from '../lib/formatters';
+import { OUTPUT_FORMATS, OutputFormat, excludeLibs, formatGraph, isOutputFormat, selectLibs } from '../lib/formatters';
 
 const SAMPLE: Edges<string> = {
   a: ['b', 'c'],
@@ -136,5 +136,31 @@ describe('excludeLibs', () => {
   it('composes with formatGraph for AI-agent style filtering', () => {
     const out = formatGraph(excludeLibs(SAMPLE, ['b']), 'edges');
     expect(out).toBe('a c\n');
+  });
+});
+
+describe('selectLibs', () => {
+  it('returns the input reference unchanged when no libs are selected', () => {
+    expect(selectLibs(SAMPLE, [])).toBe(SAMPLE);
+  });
+
+  it('keeps only the specified libs and edges between them', () => {
+    const out = selectLibs(SAMPLE, ['a', 'b']);
+    expect(out).toEqual({ a: ['b'], b: [] });
+    expect(SAMPLE).toEqual({ a: ['b', 'c'], b: ['c'], c: [] });
+  });
+
+  it('drops edges to libs outside the allowlist', () => {
+    const out = selectLibs(SAMPLE, ['a', 'c']);
+    expect(out).toEqual({ a: ['c'], c: [] });
+  });
+
+  it('produces an empty graph when none of the libs exist', () => {
+    expect(selectLibs(SAMPLE, ['x', 'y'])).toEqual({});
+  });
+
+  it('composes with excludeLibs for affected-project filtering', () => {
+    const out = formatGraph(selectLibs(excludeLibs(SAMPLE, ['c']), ['a', 'b']), 'edges');
+    expect(out).toBe('a b\n');
   });
 });


### PR DESCRIPTION
Add repeatable `-p, --projects <lib>` CLI flag to render only specified libraries and edges between them. Ideal for affected-project workflows when you already know which projects changed (e.g. from `nx show projects --affected`).

Fix affected-project recipe in README and

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-p, --projects` repeatable CLI flag to filter output to specific libraries
  * Introduced `selectLibs()` API for programmatic graph filtering

* **Documentation**
  * Updated CLI documentation and usage guide with new filtering option
  * Corrected Nx graph behavior examples in affected-project recipes

* **Tests**
  * Added test coverage for new library selection and filtering features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nx-mermaid-grapher/pull/32)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->