### PR TITLE
fix(impactLibs): forward BFS from root seeds, mermaid target-node fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-05-15
+
+### Changed
+
+- **`impactLibs` forward traversal now starts only from root seeds.** A seed is
+  considered a "root" when it does not depend on any other seed. This prevents
+  unrelated sibling dependencies of downstream dependents from being pulled into
+  the closure. For example, if `web` depends on `ui` and `utils`, selecting both
+  `ui` and `web` will no longer include `utils` in the result — only the true
+  transitive impact of the changed set is rendered.
+
+### Fixed
+
+- **`formatMermaid` now renders bare declarations for nodes that only appear as
+  targets.** Previously, a node that was a dependency but had no outgoing edges of
+  its own could be silently omitted if it was not present as a source key in the
+  edges object.
+
 ## [2.2.0] - 2026-05-15
 
 ### Added
@@ -143,7 +161,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1]: https://github.com/Fcmam5/nx-mermaid-grapher/issues/1
 
-[Unreleased]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/2.2.0...2.2.1
+[2.2.0]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/2.1.0...2.2.0
+[2.1.0]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/Fcmam5/nx-mermaid-grapher/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FFcmam5%2Fnx-mermaid-grapher%2Fdevelop)](https://dashboard.stryker-mutator.io/reports/github.com/Fcmam5/nx-mermaid-grapher/develop) [![Known Vulnerabilities](https://snyk.io/test/github/Fcmam5/nx-mermaid-grapher/badge.svg)](https://snyk.io/test/github/Fcmam5/nx-mermaid-grapher) [![codecov](https://codecov.io/gh/Fcmam5/nx-mermaid-grapher/branch/develop/graph/badge.svg?token=QSBZLLE1L1)](https://codecov.io/gh/Fcmam5/nx-mermaid-grapher) [![npm](https://img.shields.io/npm/v/nx-mermaid-grapher)](https://www.npmjs.com/package/nx-mermaid-grapher)
 
-A utility to create [`MermaidJS`](https://mermaid.js.org/) graphs for [NX dependency graphs](https://nx.dev/packages/nx/documents/dep-graph).
+A CLI and library to convert [Nx dependency graphs](https://nx.dev/packages/nx/documents/dep-graph) into compact, human-readable formats — Mermaid, Graphviz DOT, JSON, plain-text edges, and workspace stats. Built for PR descriptions, documentation, and AI agent prompts.
 
 > [!TIP]
 > **Using this from an AI coding agent?** `nx-mermaid-grapher` is designed to be
@@ -118,8 +118,8 @@ Options:
   -p, --projects <lib>   Include only these libraries (repeatable).
                          Useful for rendering affected-project subgraphs.
       --impact           When used with --projects, include the full transitive
-                         closure in both directions (seeds + all deps + all
-                         dependents).
+                         closure in both directions. Forward traversal starts
+                         from root seeds only to avoid unrelated siblings.
       --raw              Emit raw Mermaid (no ```mermaid markdown fence)
   -h, --help             Show help
   -V, --version          Show version

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -80,6 +80,7 @@ graph LR
   lending-ui-rest --> lending-domain
   lending-ui-rest --> lending-infrastructure
   lending-domain --> shared-domain
+  shared-domain
   catalogue --> shared-domain
   catalogue --> shared-infrastructure-nestjs-cqrs-events
   library --> catalogue
@@ -105,6 +106,7 @@ graph LR
   lending-ui-rest --> lending-domain
   lending-ui-rest --> lending-infrastructure
   lending-domain --> shared-domain
+  shared-domain
   catalogue --> shared-domain
   catalogue --> shared-infrastructure-nestjs-cqrs-events
   library --> catalogue
@@ -356,7 +358,17 @@ remaining graph. You can combine them for precise control.
 
 For the full transitive closure (all downstream dependencies and all upstream
 dependents), add `--impact`. This is useful when you need the complete ripple
-effect of a change:
+effect of a change.
+
+**How it works.** `--impact` performs a backward BFS from every seed (to find
+all upstream dependents) but only a *forward* BFS from the **root seeds** —
+seeds that do not depend on any other seed. This prevents unrelated sibling
+dependencies of downstream dependents from being pulled in.
+
+For example, imagine `web` depends on both `ui` and `utils`, and your affected
+set is `[ui, web]`. Because `web` depends on `ui` (another seed), `web` is not
+a root seed. Forward traversal starts only from `ui`, so `utils` is **not**
+included — only the true transitive impact of the changed set is rendered.
 
 ```bash
 npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json \

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -20,8 +20,8 @@ Options:
   -p, --projects <lib>   Include only these libraries (repeatable).
                          Useful for rendering affected-project subgraphs.
       --impact           When used with --projects, include the full transitive
-                         closure in both directions (seeds + all deps + all
-                         dependents).
+                         closure in both directions. Forward traversal starts
+                         from root seeds only to avoid unrelated siblings.
       --raw              Emit raw Mermaid (no \`\`\`mermaid markdown fence)
   -h, --help             Show help
   -V, --version          Show version`;

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -39,11 +39,13 @@ export function selectLibs(graph: Edges<string>, libraries: readonly string[]): 
 
 /**
  * Return a copy of `graph` containing the given seed libraries and every
- * node reachable from them in either direction (full transitive closure).
+ * node reachable from them in either direction.
  *
  * This includes:
- *   – all downstream dependencies of the seeds (seeds → dep → dep's deps …)
- *   – all upstream dependents of the seeds (nodes that transitively depend on
+ *   – all downstream dependencies of the ROOT seeds (seeds that do not depend
+ *     on any other seed). This prevents unrelated sibling dependencies of
+ *     downstream dependents from being pulled in.
+ *   – all upstream dependents of ANY seed (nodes that transitively depend on
  *     any seed)
  *
  * Returns the input reference unchanged when `seeds` is empty.
@@ -51,9 +53,19 @@ export function selectLibs(graph: Edges<string>, libraries: readonly string[]): 
 export function impactLibs(graph: Edges<string>, seeds: readonly string[]): Edges<string> {
   if (seeds.length === 0) return graph;
   const included = new Set<string>(seeds);
+  const seedSet = new Set<string>(seeds);
 
-  // BFS forward: everything reachable FROM seeds (downstream dependencies).
-  let frontier = new Set<string>(seeds);
+  // Root seeds: seeds that do NOT depend on any other seed.
+  // These are the projects that actually changed (not just pulled in as
+  // dependents of another seed). Forward BFS starts from roots only so
+  // unrelated sibling dependencies of downstream dependents are not pulled in.
+  const roots = seeds.filter((seed) => {
+    const deps = graph[seed] ?? [];
+    return !deps.some((dep) => seedSet.has(dep));
+  });
+
+  // BFS forward: everything reachable FROM root seeds (downstream dependencies).
+  let frontier = new Set<string>(roots);
   while (frontier.size > 0) {
     const next = new Set<string>();
     for (const node of frontier) {
@@ -75,7 +87,7 @@ export function impactLibs(graph: Edges<string>, seeds: readonly string[]): Edge
     }
   }
 
-  // BFS backward: everything that can reach TO seeds (upstream dependents).
+  // BFS backward: everything that can reach TO any seed (upstream dependents).
   frontier = new Set<string>(seeds);
   while (frontier.size > 0) {
     const next = new Set<string>();
@@ -141,7 +153,10 @@ function withOutgoing(edges: Edges<string>): string[] {
 
 function formatMermaid(edges: Edges<string>): string {
   const lines: string[] = [];
+  const seen = new Set<string>();
+
   for (const [lib, deps] of Object.entries(edges)) {
+    seen.add(lib);
     if (deps.length === 0) {
       lines.push(`  ${lib}\n`);
     } else {
@@ -150,6 +165,17 @@ function formatMermaid(edges: Edges<string>): string {
       }
     }
   }
+
+  // Bare declarations for nodes that only appear as targets (not as source keys).
+  for (const deps of Object.values(edges)) {
+    for (const dep of deps) {
+      if (!seen.has(dep)) {
+        seen.add(dep);
+        lines.push(`  ${dep}\n`);
+      }
+    }
+  }
+
   return `graph LR\n${lines.join('')}`;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nx-mermaid-grapher",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nx-mermaid-grapher",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "bin": {
         "nx-mermaid-grapher": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "nx-mermaid-grapher",
-  "version": "2.2.0",
-  "description": "Create MermaidJS graphs from NX dependency graphs",
+  "version": "2.2.1",
+  "description": "Convert Nx dependency graphs into Mermaid, Graphviz, JSON, and other compact formats. Filter by project, compute impact closures, and generate token-cheap topology views for humans and AI agents.",
   "main": "dist/cli.js",
   "files": [
     "dist",
     "!dist/**/*.map"
   ],
   "bin": {
-    "nx-mermaid-grapher": "./dist/cli.js"
+    "nx-mermaid-grapher": "dist/cli.js"
   },
   "types": "dist/index.d.ts",
   "scripts": {
@@ -34,6 +34,17 @@
   "bugs": {
     "url": "https://github.com/Fcmam5/nx-mermaid-grapher/issues"
   },
+  "keywords": [
+    "nx",
+    "nrwl",
+    "monorepo",
+    "dependency-graph",
+    "mermaid",
+    "graphviz",
+    "visualization",
+    "cli",
+    "ai-agents"
+  ],
   "homepage": "https://github.com/Fcmam5/nx-mermaid-grapher#readme",
   "engines": {
     "node": ">=22"

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -217,8 +217,8 @@ describe('impactLibs', () => {
   it('handles seeds where only the head is a root', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: [] };
     const out = impactLibs(graph, ['b', 'c']);
-    // c depends on b (another seed), so only b is a root.
-    // Forward BFS from b finds c; backward BFS from [b,c] finds a.
+    // b depends on c (another seed), so only c is a root.
+    // Forward BFS from c finds nothing; backward BFS from [b,c] finds a.
     expect(out).toEqual({ a: ['b'], b: ['c'], c: [] });
   });
 

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -35,6 +35,10 @@ describe('formatGraph', () => {
     it('renders isolated nodes as bare declarations', () => {
       expect(formatGraph({ orphan: [] }, 'mermaid')).toBe('graph LR\n  orphan\n');
     });
+
+    it('renders nodes that only appear as targets (not source keys)', () => {
+      expect(formatGraph({ a: ['b'] }, 'mermaid')).toBe('graph LR\n  a --> b\n  b\n');
+    });
   });
 
   describe('edges', () => {
@@ -208,5 +212,32 @@ describe('impactLibs', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: ['a'] };
     const out = impactLibs(graph, ['a']);
     expect(out).toEqual({ a: ['b'], b: ['c'], c: ['a'] });
+  });
+
+  it('handles seeds where only the head is a root', () => {
+    const graph: Edges<string> = { a: ['b'], b: ['c'], c: [] };
+    const out = impactLibs(graph, ['b', 'c']);
+    // c depends on b (another seed), so only b is a root.
+    // Forward BFS from b finds c; backward BFS from [b,c] finds a.
+    expect(out).toEqual({ a: ['b'], b: ['c'], c: [] });
+  });
+
+  it('does not pull in unrelated sibling deps of a dependent seed', () => {
+    // web depends on ui (root) and utils (unrelated).
+    // When both ui and web are seeds, utils should NOT be included
+    // because forward BFS starts only from the root seed (ui).
+    const graph: Edges<string> = {
+      web: ['ui', 'utils'],
+      ui: ['shared'],
+      shared: [],
+      utils: [],
+    };
+    const out = impactLibs(graph, ['ui', 'web']);
+    expect(out).toEqual({
+      web: ['ui'],
+      ui: ['shared'],
+      shared: [],
+    });
+    expect(out).not.toHaveProperty('utils');
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Impact analysis now properly constrains forward traversal to root seeds, preventing unrelated sibling dependencies from being included
  * Mermaid output now renders all referenced nodes, including those appearing only as targets

* **Documentation**
  * Updated `--impact` option documentation with clearer behavior descriptions
  * Enhanced usage guide with concrete examples and scenarios

* **Tests**
  * Added test coverage for target-only node rendering in Mermaid output
  * Extended impact analysis tests for root seed behavior validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nx-mermaid-grapher/pull/36)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->