### PR TITLE
chore: rename `--impact` to `--transitive`, deprecate old names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`impactLibs` function renamed to `transitiveLibs`.** The `impactLibs` function
+  is now deprecated but remains functional as an alias for backward compatibility.
+  A deprecation warning is printed when `impactLibs` is called. Use `transitiveLibs`
+  instead in all new code and documentation.
+- **`--impact` CLI flag renamed to `--transitive` (short flag: `-t`).** The
+  `--impact` flag is now deprecated but remains functional as an alias for
+  backward compatibility. A deprecation warning is printed when `--impact` is used.
+  Use `--transitive` or `-t` instead in all new code and documentation.
+- **`NxMermaidGrapher.getGraphSnippet` parameter renamed.** The `impact` parameter
+  is now deprecated in favor of `transitive`. The old `impact` parameter remains
+  functional for backward compatibility with a deprecation warning.
+
 ## [2.2.1] - 2026-05-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npx nx-mermaid-grapher -f file.json
 Then, run it with `-f [PATH]` or `--file [PATH]` parameter providing the path for your NX graph JSON output file.
 
 ```
-Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [--impact] [--raw]
+Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [-t] [--raw]
 
 Options:
   -f, --file <path>      NX graph output file. Pass `-` to read from stdin
@@ -117,7 +117,7 @@ Options:
   -e, --exclude <lib>    Exclude a library (repeatable)
   -p, --projects <lib>   Include only these libraries (repeatable).
                          Useful for rendering affected-project subgraphs.
-      --impact           When used with --projects, include the full transitive
+  -t, --transitive       When used with --projects, include the full transitive
                          closure in both directions. Forward traversal starts
                          from root seeds only to avoid unrelated siblings.
       --raw              Emit raw Mermaid (no ```mermaid markdown fence)
@@ -279,15 +279,15 @@ const core = new NxMermaidGrapher(loader, myGraph);
 npx nx graph --file=graph.json
 
 # 2. Get the names of affected projects and render with impact context.
-#    --impact includes the full transitive closure around the affected set.
+#    -t includes the full transitive closure around the affected set.
 #    Requires `jq`; adjust --base to your target branch.
-npx nx-mermaid-grapher -f graph.json --impact \
+npx nx-mermaid-grapher -f graph.json -t \
   $(npx nx show projects --affected --json --base=origin/develop \
     | jq -r '.[] | "-p " + .')
 ```
 
 You can swap `--base=origin/develop` for `origin/main` (or any commit-ish) and
-still combine with `-e <lib>` to hide noisy projects. Omit `--impact` if you only
+still combine with `-e <lib>` to hide noisy projects. Omit `--transitive` if you only
 want the strictly affected projects with no surrounding context.
 
 ### Auto-post the affected graph as a PR comment (GitHub Actions)
@@ -334,7 +334,7 @@ jobs:
           {
             echo '## Affected dependency graph'
             echo
-            npx nx-mermaid-grapher -f graph.json --impact $PROJECTS
+            npx nx-mermaid-grapher -f graph.json -t $PROJECTS
           } > graph.md
 
       - name: Comment on the PR

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -357,10 +357,10 @@ The two flags compose: `--exclude` runs first, then `--projects` filters the
 remaining graph. You can combine them for precise control.
 
 For the full transitive closure (all downstream dependencies and all upstream
-dependents), add `--impact`. This is useful when you need the complete ripple
+dependents), add `-t` or `--transitive`. This is useful when you need the complete ripple
 effect of a change.
 
-**How it works.** `--impact` performs a backward BFS from every seed (to find
+**How it works.** `-t`/`--transitive` performs a backward BFS from every seed (to find
 all upstream dependents) but only a *forward* BFS from the **root seeds** —
 seeds that do not depend on any other seed. This prevents unrelated sibling
 dependencies of downstream dependents from being pulled in.
@@ -372,7 +372,7 @@ included — only the true transitive impact of the changed set is rendered.
 
 ```bash
 npx nx-mermaid-grapher -f tests/mocks/ddd-example.graph.json \
-  -p lending-infrastructure --impact
+  -p lending-infrastructure -t
 ```
 
 ## Using the library programmatically
@@ -416,10 +416,10 @@ const trimmedDot = formatGraph(excludeLibs(graph, ['noisy-lib']), 'dot');
 const affected = selectLibs(graph, ['lending-infrastructure', 'lending-application']);
 const affectedMermaid = formatGraph(affected, 'mermaid');
 
-// Show impact context — affected projects plus full transitive closure:
-import { impactLibs } from 'nx-mermaid-grapher';
-const withImpact = impactLibs(graph, ['lending-infrastructure', 'lending-application']);
-const impactMermaid = formatGraph(withImpact, 'mermaid');
+// Show transitive context — affected projects plus full transitive closure:
+import { transitiveLibs } from 'nx-mermaid-grapher';
+const withTransitive = transitiveLibs(graph, ['lending-infrastructure', 'lending-application']);
+const transitiveMermaid = formatGraph(withTransitive, 'mermaid');
 ```
 
 You can also bring your own graph data structure by implementing `IGraph<T>`

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -8,7 +8,7 @@ import { isOutputFormat, OUTPUT_FORMATS } from './formatters';
 import { NXGraphFileLoader, STDIN_PATH } from './nx/load-nx-graph';
 import { NxMermaidGrapher } from './core';
 
-export const USAGE = `Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [--impact] [--raw]
+export const USAGE = `Usage: nx-mermaid-grapher (-f <path> | --stdin) [-o <format>] [-e <lib>]... [-p <lib>]... [-t] [--raw]
 
 Options:
   -f, --file <path>      NX graph output file. Pass \`-\` to read from stdin
@@ -19,9 +19,10 @@ Options:
   -e, --exclude <lib>    Exclude a library (repeatable)
   -p, --projects <lib>   Include only these libraries (repeatable).
                          Useful for rendering affected-project subgraphs.
-      --impact           When used with --projects, include the full transitive
+  -t, --transitive       When used with --projects, include the full transitive
                          closure in both directions. Forward traversal starts
                          from root seeds only to avoid unrelated siblings.
+      --impact            (deprecated: use --transitive instead)
       --raw              Emit raw Mermaid (no \`\`\`mermaid markdown fence)
   -h, --help             Show help
   -V, --version          Show version`;
@@ -59,6 +60,7 @@ export function run(argv: string[]): string {
         format: { type: 'string', short: 'o' },
         exclude: { type: 'string', short: 'e', multiple: true },
         projects: { type: 'string', short: 'p', multiple: true },
+        transitive: { type: 'boolean', short: 't' },
         impact: { type: 'boolean' },
         raw: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
@@ -89,11 +91,17 @@ export function run(argv: string[]): string {
     throw new CliError(`invalid --format '${format}'. Choose one of: ${OUTPUT_FORMATS.join(', ')}`);
   }
 
+  // Handle deprecation of --impact
+  if (values.impact) {
+    console.error('warning: --impact is deprecated. Use --transitive instead.');
+  }
+  const useTransitive = values.transitive || values.impact;
+
   const core = new NxMermaidGrapher(new NXGraphFileLoader(), new DiGraph());
   core.init(inputPath);
 
   const selected = values.projects?.length ? values.projects : undefined;
-  const body = core.getGraphSnippet(values.exclude, format, selected, values.impact);
+  const body = core.getGraphSnippet(values.exclude, format, selected, useTransitive);
 
   // Wrap Mermaid output in a markdown code fence by default so users can paste
   // it straight into a PR description or README. Use --raw to opt out.

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -33,7 +33,7 @@ export class NxMermaidGrapher {
     if (impact !== undefined) {
       console.error('warning: impact parameter is deprecated. Use transitive instead.');
     }
-    const useTransitive = transitive || impact;
+    const useTransitive = transitive !== undefined ? transitive : impact;
 
     let rs = excludeLibs(this.graph.getGraph(), excludedLibs);
     if (selectedLibraries) {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -1,5 +1,5 @@
 import { IGraph } from './data-structures/graph.ds.interface';
-import { excludeLibs, formatGraph, impactLibs, OutputFormat, selectLibs } from './formatters';
+import { excludeLibs, formatGraph, transitiveLibs, OutputFormat, selectLibs } from './formatters';
 import { GraphJsonResponse } from './nx/interfaces/graph-json.nx.interface';
 import { NXGraphFileLoader } from './nx/load-nx-graph';
 
@@ -26,11 +26,18 @@ export class NxMermaidGrapher {
     excludedLibs: string[] = [],
     format: OutputFormat = 'mermaid',
     selectedLibraries?: string[],
+    transitive?: boolean,
     impact?: boolean,
   ): string {
+    // Handle deprecation of impact parameter
+    if (impact !== undefined) {
+      console.error('warning: impact parameter is deprecated. Use transitive instead.');
+    }
+    const useTransitive = transitive || impact;
+
     let rs = excludeLibs(this.graph.getGraph(), excludedLibs);
     if (selectedLibraries) {
-      rs = impact ? impactLibs(rs, selectedLibraries) : selectLibs(rs, selectedLibraries);
+      rs = useTransitive ? transitiveLibs(rs, selectedLibraries) : selectLibs(rs, selectedLibraries);
     }
     return formatGraph(rs, format);
   }

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -50,7 +50,7 @@ export function selectLibs(graph: Edges<string>, libraries: readonly string[]): 
  *
  * Returns the input reference unchanged when `seeds` is empty.
  */
-export function impactLibs(graph: Edges<string>, seeds: readonly string[]): Edges<string> {
+export function transitiveLibs(graph: Edges<string>, seeds: readonly string[]): Edges<string> {
   if (seeds.length === 0) return graph;
   const included = new Set<string>(seeds);
   const seedSet = new Set<string>(seeds);
@@ -102,12 +102,21 @@ export function impactLibs(graph: Edges<string>, seeds: readonly string[]): Edge
     frontier = next;
   }
 
+  // Build result: keep only edges between included nodes.
   const result: Edges<string> = {};
   for (const [lib, deps] of Object.entries(graph)) {
     if (!included.has(lib)) continue;
     result[lib] = deps.filter((dep) => included.has(dep));
   }
   return result;
+}
+
+/**
+ * @deprecated Use `transitiveLibs` instead.
+ */
+export function impactLibs(graph: Edges<string>, seeds: readonly string[]): Edges<string> {
+  console.error('warning: impactLibs is deprecated. Use transitiveLibs instead.');
+  return transitiveLibs(graph, seeds);
 }
 
 export type OutputFormat = 'mermaid' | 'edges' | 'json' | 'dot' | 'stats';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ export { NxMermaidGrapher } from './core';
 export {
   excludeLibs,
   formatGraph,
+  transitiveLibs,
   impactLibs,
   isOutputFormat,
   selectLibs,

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -75,13 +75,14 @@ describe('CLI run()', () => {
   });
 
   it('--impact is deprecated and prints a warning', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
     const out = run(['-f', FIXTURE, '-p', 'lending-domain', '--impact']);
 
     // Should still work functionally
     expect(out).toContain('lending-application --> lending-domain');
     // Should print deprecation warning to stderr
-    // Note: console.error is captured in tests, but we can't easily test it here
-    // The warning is: 'warning: --impact is deprecated. Use --transitive instead.'
+    expect(consoleErrorSpy).toHaveBeenCalledWith('warning: --impact is deprecated. Use --transitive instead.');
+    consoleErrorSpy.mockRestore();
   });
 
   it('returns USAGE for --help', () => {

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { CliError, run, USAGE } from '../lib/cli';
 
 const FIXTURE = join(__dirname, 'mocks', 'ddd-example.graph.json');
+const SIMPLE_DEMO = join(__dirname, 'mocks', 'simple-demo.graph.json');
 const realReadFileSync = jest.requireActual('node:fs').readFileSync as typeof readFileSync;
 const FIXTURE_CONTENT = realReadFileSync(FIXTURE, 'utf-8') as string;
 const mockedReadFileSync = readFileSync as unknown as jest.MockedFunction<typeof readFileSync>;
@@ -57,12 +58,30 @@ describe('CLI run()', () => {
     expect(out).not.toContain('library');
   });
 
-  it('honours --impact by including full transitive closure', () => {
-    const out = run(['-f', FIXTURE, '-p', 'lending-domain', '--impact']);
+  it('honours --transitive by including full transitive closure', () => {
+    const out = run(['-f', FIXTURE, '-p', 'lending-domain', '--transitive']);
 
     // Should include the full chain up to roots and down to leaves.
     expect(out).toContain('lending-application --> lending-domain');
     expect(out).toContain('lending-infrastructure --> lending-application');
+  });
+
+  it('honours -t (short flag for --transitive)', () => {
+    const out = run(['-f', FIXTURE, '-p', 'lending-domain', '-t']);
+
+    // Should work the same as --transitive
+    expect(out).toContain('lending-application --> lending-domain');
+    expect(out).toContain('lending-infrastructure --> lending-application');
+  });
+
+  it('--impact is deprecated and prints a warning', () => {
+    const out = run(['-f', FIXTURE, '-p', 'lending-domain', '--impact']);
+
+    // Should still work functionally
+    expect(out).toContain('lending-application --> lending-domain');
+    // Should print deprecation warning to stderr
+    // Note: console.error is captured in tests, but we can't easily test it here
+    // The warning is: 'warning: --impact is deprecated. Use --transitive instead.'
   });
 
   it('returns USAGE for --help', () => {
@@ -153,5 +172,78 @@ describe('CLI run()', () => {
     it('throws CliError for an unknown format', () => {
       expect(() => run(['-f', FIXTURE, '-o', 'graphviz'])).toThrow(/invalid --format/);
     });
+  });
+});
+
+describe('CLI run() with SIMPLE_DEMO fixture', () => {
+  it('renders the full graph for the simple demo', () => {
+    const out = run(['-f', SIMPLE_DEMO]);
+
+    expect(out).toContain('graph LR\n');
+    expect(out).toContain('data --> shared');
+    expect(out).toContain('api --> utils');
+    expect(out).toContain('api --> data');
+    expect(out).toContain('web --> ui');
+    expect(out).toContain('web --> utils');
+    expect(out).toContain('ui --> shared');
+  });
+
+  it('filters by --projects to show only selected libs', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-p', 'web', '-p', 'ui']);
+
+    expect(out).toContain('web --> ui');
+    // ui --> shared is filtered out because shared is not in selected projects
+    expect(out).not.toContain('ui --> shared');
+    expect(out).not.toContain('api');
+    expect(out).not.toContain('data');
+    expect(out).not.toContain('utils');
+  });
+
+  it('--transitive with single seed includes downstream dependencies', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-p', 'web', '--transitive']);
+
+    // web is a root seed (doesn't depend on any other seed)
+    // Forward BFS: web --> ui --> shared, web --> utils
+    expect(out).toContain('web --> ui');
+    expect(out).toContain('web --> utils');
+    expect(out).toContain('ui --> shared');
+  });
+
+  it('--transitive with multiple seeds uses root-seeds logic', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-p', 'web', '-p', 'ui', '--transitive']);
+
+    // web depends on ui (another seed), so web is NOT a root
+    // ui is a root seed (doesn't depend on any other seed)
+    // Forward BFS from ui only: ui --> shared
+    // utils should NOT be included (unrelated sibling of web)
+    expect(out).toContain('web --> ui');
+    expect(out).toContain('ui --> shared');
+    expect(out).not.toContain('utils');
+  });
+
+  it('--exclude removes specified libraries', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-e', 'utils']);
+
+    expect(out).not.toContain('utils');
+    expect(out).not.toContain('api --> utils');
+    expect(out).not.toContain('web --> utils');
+    expect(out).toContain('data --> shared');
+    expect(out).toContain('web --> ui');
+  });
+
+  it('--format edges emits plain edge list', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-o', 'edges']);
+
+    expect(out).not.toContain('```');
+    expect(out).toContain('data shared');
+    expect(out).toContain('api utils');
+    expect(out).toContain('api data');
+  });
+
+  it('--format stats emits graph summary', () => {
+    const out = run(['-f', SIMPLE_DEMO, '-o', 'stats']);
+
+    expect(out).toMatch(/nodes:\s+6/);
+    expect(out).toMatch(/edges:\s+6/);
   });
 });

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -113,7 +113,10 @@ describe('Library core', () => {
     });
 
     it('should support deprecated impact parameter', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       const out = coreCls.getGraphSnippet([], 'mermaid', ['lending-domain'], undefined, true);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('warning: impact parameter is deprecated. Use transitive instead.');
+      consoleErrorSpy.mockRestore();
       expect(out).toContain('lending-application --> lending-domain');
       expect(out).toContain('lending-infrastructure --> lending-application');
       expect(out).not.toContain('catalogue');

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -105,8 +105,15 @@ describe('Library core', () => {
       expect(out).not.toContain('catalogue');
     });
 
-    it('should include full transitive closure with impact=true', () => {
+    it('should include full transitive closure with transitive=true', () => {
       const out = coreCls.getGraphSnippet([], 'mermaid', ['lending-domain'], true);
+      expect(out).toContain('lending-application --> lending-domain');
+      expect(out).toContain('lending-infrastructure --> lending-application');
+      expect(out).not.toContain('catalogue');
+    });
+
+    it('should support deprecated impact parameter', () => {
+      const out = coreCls.getGraphSnippet([], 'mermaid', ['lending-domain'], undefined, true);
       expect(out).toContain('lending-application --> lending-domain');
       expect(out).toContain('lending-infrastructure --> lending-application');
       expect(out).not.toContain('catalogue');

--- a/tests/formatters.spec.ts
+++ b/tests/formatters.spec.ts
@@ -4,7 +4,7 @@ import {
   OutputFormat,
   excludeLibs,
   formatGraph,
-  impactLibs,
+  transitiveLibs,
   isOutputFormat,
   selectLibs,
 } from '../lib/formatters';
@@ -177,46 +177,46 @@ describe('selectLibs', () => {
   });
 });
 
-describe('impactLibs', () => {
+describe('transitiveLibs', () => {
   it('returns the input reference unchanged when no seeds are given', () => {
-    expect(impactLibs(SAMPLE, [])).toBe(SAMPLE);
+    expect(transitiveLibs(SAMPLE, [])).toBe(SAMPLE);
   });
 
   it('follows downstream dependencies recursively', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: ['d'], d: [] };
-    const out = impactLibs(graph, ['a']);
+    const out = transitiveLibs(graph, ['a']);
     expect(out).toEqual({ a: ['b'], b: ['c'], c: ['d'], d: [] });
   });
 
   it('follows upstream dependents recursively', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: ['d'], d: [] };
-    const out = impactLibs(graph, ['d']);
+    const out = transitiveLibs(graph, ['d']);
     expect(out).toEqual({ a: ['b'], b: ['c'], c: ['d'], d: [] });
   });
 
   it('keeps edges only between included nodes', () => {
     const graph: Edges<string> = { a: ['b', 'x'], b: ['c'], c: [], x: [] };
-    const out = impactLibs(graph, ['a']);
+    const out = transitiveLibs(graph, ['a']);
     // x is a direct dep of a, so it's included; edge a->x is preserved.
     expect(out).toEqual({ a: ['b', 'x'], b: ['c'], c: [], x: [] });
   });
 
   it('drops edges to nodes outside the transitive closure', () => {
     const graph: Edges<string> = { a: ['b', 'x'], b: ['c'], c: [], x: ['y'], y: [] };
-    const out = impactLibs(graph, ['b']);
+    const out = transitiveLibs(graph, ['b']);
     // a and c are in the closure (upstream/downstream of b); x and y are not.
     expect(out).toEqual({ a: ['b'], b: ['c'], c: [] });
   });
 
   it('handles cycles gracefully', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: ['a'] };
-    const out = impactLibs(graph, ['a']);
+    const out = transitiveLibs(graph, ['a']);
     expect(out).toEqual({ a: ['b'], b: ['c'], c: ['a'] });
   });
 
   it('handles seeds where only the head is a root', () => {
     const graph: Edges<string> = { a: ['b'], b: ['c'], c: [] };
-    const out = impactLibs(graph, ['b', 'c']);
+    const out = transitiveLibs(graph, ['b', 'c']);
     // b depends on c (another seed), so only c is a root.
     // Forward BFS from c finds nothing; backward BFS from [b,c] finds a.
     expect(out).toEqual({ a: ['b'], b: ['c'], c: [] });
@@ -232,7 +232,7 @@ describe('impactLibs', () => {
       shared: [],
       utils: [],
     };
-    const out = impactLibs(graph, ['ui', 'web']);
+    const out = transitiveLibs(graph, ['ui', 'web']);
     expect(out).toEqual({
       web: ['ui'],
       ui: ['shared'],

--- a/tests/mocks/simple-demo.graph.json
+++ b/tests/mocks/simple-demo.graph.json
@@ -1,0 +1,162 @@
+{
+  "graph": {
+    "nodes": {
+      "shared": {
+        "name": "shared",
+        "type": "lib",
+        "data": {
+          "root": "libs/shared",
+          "name": "shared",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "libs/shared/src",
+          "projectType": "library",
+          "tags": [],
+          "targets": {},
+          "implicitDependencies": []
+        }
+      },
+      "utils": {
+        "name": "utils",
+        "type": "lib",
+        "data": {
+          "root": "libs/utils",
+          "name": "utils",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "libs/utils/src",
+          "projectType": "library",
+          "tags": [],
+          "targets": {},
+          "implicitDependencies": []
+        }
+      },
+      "data": {
+        "name": "data",
+        "type": "lib",
+        "data": {
+          "root": "libs/data",
+          "name": "data",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "libs/data/src",
+          "projectType": "library",
+          "tags": [],
+          "targets": {},
+          "implicitDependencies": []
+        }
+      },
+      "api": {
+        "name": "api",
+        "type": "app",
+        "data": {
+          "root": "apps/api",
+          "name": "api",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "apps/api/src",
+          "projectType": "application",
+          "tags": [],
+          "implicitDependencies": [
+            "utils"
+          ],
+          "targets": {
+            "build": {
+              "executor": "nx:run-commands",
+              "options": {
+                "command": "echo 'Building api app'"
+              },
+              "configurations": {},
+              "parallelism": true,
+              "inputs": [
+                "production",
+                "^production"
+              ],
+              "cache": true
+            }
+          }
+        }
+      },
+      "web": {
+        "name": "web",
+        "type": "app",
+        "data": {
+          "root": "apps/web",
+          "name": "web",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "apps/web/src",
+          "projectType": "application",
+          "tags": [],
+          "targets": {
+            "build": {
+              "executor": "nx:run-commands",
+              "options": {
+                "command": "echo 'Building web app'"
+              },
+              "configurations": {},
+              "parallelism": true,
+              "inputs": [
+                "production",
+                "^production"
+              ],
+              "cache": true
+            }
+          },
+          "implicitDependencies": []
+        }
+      },
+      "ui": {
+        "name": "ui",
+        "type": "lib",
+        "data": {
+          "root": "libs/ui",
+          "name": "ui",
+          "$schema": "../../node_modules/nx/schemas/project-schema.json",
+          "sourceRoot": "libs/ui/src",
+          "projectType": "library",
+          "tags": [],
+          "targets": {},
+          "implicitDependencies": []
+        }
+      }
+    },
+    "dependencies": {
+      "shared": [],
+      "utils": [],
+      "data": [
+        {
+          "source": "data",
+          "target": "shared",
+          "type": "static"
+        }
+      ],
+      "api": [
+        {
+          "source": "api",
+          "target": "utils",
+          "type": "implicit"
+        },
+        {
+          "source": "api",
+          "target": "data",
+          "type": "static"
+        }
+      ],
+      "web": [
+        {
+          "source": "web",
+          "target": "ui",
+          "type": "static"
+        },
+        {
+          "source": "web",
+          "target": "utils",
+          "type": "static"
+        }
+      ],
+      "ui": [
+        {
+          "source": "ui",
+          "target": "shared",
+          "type": "static"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Rename `--impact` CLI flag to `--transitive` (short: `-t`), `impactLibs()` function to `transitiveLibs()`, and `impact` parameter to `transitive` in `getGraphSnippet()`. Old names remain functional as deprecated aliases with warnings. Update all documentation and examples to use new terminology.

- Add simple-demo.graph.json fixture for integration tests"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI, README and usage guides to use the new --transitive (-t) option in examples and recipes.

* **Changed**
  * Renamed --impact to --transitive (short -t); the old flag remains supported but emits a deprecation warning.
  * Renamed impactLibs behavior to transitiveLibs; the old name is kept as a deprecated alias that warns on use.

* **Tests**
  * Added/updated tests and fixtures to cover transitive behavior, CLI usage, and deprecation warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fcmam5/nx-mermaid-grapher/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->